### PR TITLE
Remove dublicate function

### DIFF
--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -397,7 +397,6 @@ module MqClient =
             }
 
 
-
     let replyToMessage: Model -> ReceivedMessage -> (string * string) list -> Content -> Async<PublishResult> =
         fun (Model model) receivedMessage headers content ->
             receivedMessage
@@ -432,9 +431,9 @@ module MqClient =
 
     /// <summary>Make an RPC-call to a RabbitMq queue.</summary>
     /// <param name="Model">MqClient model.</param>
-    /// <param name="timeout">Seconds before timeing out request</param>
-    /// <param name="routingKey">Routing key to publish message to</param>
-    /// <param name="message">Message to be published</param>
+    /// <param name="timeout">Seconds before timing out request.</param>
+    /// <param name="routingKey">Routing key to publish message to.</param>
+    /// <param name="message">Message to be published.</param>
     /// <returns>Response from called RPC endpoint or error.</returns>
     let request: Model -> System.TimeSpan -> string -> PublishMessage -> AsyncResult<ReceivedMessage, string> =
         fun (Model model) timeout routingKey message ->

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -432,7 +432,9 @@ module MqClient =
 
     /// <summary>Make an RPC-call to a RabbitMq queue.</summary>
     /// <param name="Model">MqClient model.</param>
-    /// <param name="config">Config for where to publish and what to publish.</param>
+    /// <param name="timeout">Seconds before timeing out request</param>
+    /// <param name="routingKey">Routing key to publish message to</param>
+    /// <param name="message">Message to be published</param>
     /// <returns>Response from called RPC endpoint or error.</returns>
     let request: Model -> System.TimeSpan -> string -> PublishMessage -> AsyncResult<ReceivedMessage, string> =
         fun (Model model) timeout routingKey message ->


### PR DESCRIPTION
### Problem
We have an deprecated function `respond ` that has been replaced with `replyToMessage`

### Solution
Remove deprecated function and refactor PublishConfig to make more sense and use arguments for timeout and routingKey.

closes https://github.com/insurello/Insurello.RabbitMqClient/issues/2