### PR TITLE
Add PDB in main package

### DIFF
--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -9,11 +9,18 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/insurello/Insurello.RabbitMqClient</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <!-- Source Link configuration -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <!-- Include PDB in the main package as current tooling is lacking.
+         Shall be removed in the future when tooling has catched up. -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
+  <!-- Source Link repo configuration -->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>


### PR DESCRIPTION
### Problem

F# tooling for Mac is not supporting Source Link that well :/

### Solution

Include PDB in main package to hopefully get some debug information.
