### PR TITLE
Correlation id custom type

### DIFF
--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -67,7 +67,6 @@ module MqClient =
 
     type PrefetchCount = PrefetchCount of uint16
 
-
     let private contentTypeStringFromContent: Content -> string =
         function
         | Json _ -> "application/json"

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -52,8 +52,12 @@ module MqClient =
         | Json of string
         | Binary of byte array
 
+    type CorrelationId =
+        | Generate
+        | Id of string
+
     type PublishMessage =
-        { CorrelationId: string
+        { CorrelationId: CorrelationId
           Headers: Map<string, string>
           Content: Content }
 
@@ -62,6 +66,7 @@ module MqClient =
           prefetchCount: uint16 }
 
     type PrefetchCount = PrefetchCount of uint16
+
 
     let private contentTypeStringFromContent: Content -> string =
         function

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -436,7 +436,10 @@ module MqClient =
                                      (ContentType = contentTypeStringFromContent message.Content,
                                       Persistent = true,
                                       MessageId = messageId,
-                                      CorrelationId = message.CorrelationId,
+                                      CorrelationId =
+                                          (match message.CorrelationId with
+                                           | Generate -> ""
+                                           | Id correlationId -> correlationId),
                                       Headers =
                                           (message.Headers
                                            |> Map.map (fun _ v -> v :> obj)


### PR DESCRIPTION
### Problem
If CorrelationId is left as a empty string when publishing a message a unique UUID is generated as a messageId this is confusing because an expected behaviour would have been an empty CorrelationId.

### Soluton
Make a Custom type 
`CorrelationId = Generate | Id of string`

Closes https://github.com/insurello/Insurello.RabbitMqClient/issues/7