### PR TITLE
Pin FSharp.Core package to 6.0.0

### DIFF
--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -33,4 +33,12 @@
     <PackageReference Include="Insurello.AsyncExtra" Version="3.0.0" />
     <PackageReference Include="RabbitMq.Client" Version="5.1.2" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <!-- Pin FSharp.Core package to minimum supported 6.0.0
+     https://github.com/dotnet/fsharp/blob/main/docs/fsharp-core-notes.md
+     -->
+    <PackageReference Update="FSharp.Core" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### Problem
When publishing the package to nuget the `FSharp.Core` package get locked to the latest available version. We want to support version 6.

### Solution
We pin the `FSharp.Core` version to `6.0.0` by adding it to the `.fsproj` as described in https://github.com/dotnet/fsharp/blob/main/docs/fsharp-core-notes.md