### PR TITLE
Allow configuring queue type

### DIFF
--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -54,7 +54,10 @@ module MqClient =
         { Queue: string
           BindToExchange: string option
           ConsumeCallbacks: Callbacks
-          MessageTimeToLive: int option }
+          MessageTimeToLive: int option
+          QueueType: QueueType }
+        
+    and QueueType = | Classic | Quorum
 
     [<RequireQualifiedAccessAttribute>]
     type PublishResult =

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -56,8 +56,10 @@ module MqClient =
           ConsumeCallbacks: Callbacks
           MessageTimeToLive: int option
           QueueType: QueueType }
-        
-    and QueueType = | Classic | Quorum
+
+    and QueueType =
+        | Classic
+        | Quorum
 
     [<RequireQualifiedAccessAttribute>]
     type PublishResult =
@@ -276,9 +278,9 @@ module MqClient =
             let arguments =
                 dict (
                     [ "x-queue-type",
-                      (match queueTopology.BindToExchange with
-                       | Some _ -> "quorum"
-                       | None -> "classic")
+                      (match queueTopology.QueueType with
+                       | Quorum -> "quorum"
+                       | Classic -> "classic")
                       :> obj ]
                     @ (queueTopology.MessageTimeToLive
                        |> Option.map (fun ttl -> [ ("x-message-ttl", ttl :> obj) ])


### PR DESCRIPTION
In https://github.com/insurello/Insurello.RabbitMqClient/pull/25 we added a convention that if a queue is bound to exchange it becomes quorum, otherwise classic. We then realized that sometimes we want a quorum queue even if not bound to an exchange. This PR lets you specify which type you want on each queue.