### PR TITLE
One connection, many channels

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fantomas-tool": {
-      "version": "4.7.0",
+    "fantomas": {
+      "version": "7.0.5",
       "commands": ["fantomas"]
     }
   }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+[*.fs]
+# Configures fantomas - https://fsprojects.github.io/fantomas/docs/end-users/Configuration.html
+# 
+# We strive to always use the defaults to prevent bikeshedding unless we have solid use cases against.
+#
+# Overrides:
+
+# To force eventual Windows users to keep using line feeds for simpler git diffs.
+end_of_line=lf
+
+# Faster to edit lists and records as you don't have to match ending blocks.
+fsharp_multiline_bracket_style=stroustrup
+
+# Faster to see where a lambda ends.
+fsharp_multi_line_lambda_closing_newline=true
+
+# Prevents accidental new lines.
+fsharp_keep_max_number_of_blank_lines=1
+
+# Some(x) => Some (x) so that Rider will detect unnecessary parentheses.
+fsharp_space_before_uppercase_invocation=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build and test
+    name: Build
     runs-on: ubuntu-latest
     env:
       DOTNET_NOLOGO: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,28 +3,28 @@ name: Build and Test
 on:
   push:
     branches:
-      - '*'
+      - "*"
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "6.0.202"
+          global-json-file: global.json
 
-      - run: |
-          dotnet restore
+      - name: fantomas
+        run: |
           dotnet tool restore
-        env:
-          DOTNET_NOLOGO: true
+          dotnet fantomas --check src/
 
-      - run: dotnet fantomas -- --check --recurse src/
-      - run: dotnet build --configuration Release --no-restore -warnaserror
-      - run: dotnet test --no-build
+      - run: dotnet restore
+      - run: dotnet build --configuration Release --no-restore --warnaserror

--- a/.github/workflows/publish_to_NuGet.yml
+++ b/.github/workflows/publish_to_NuGet.yml
@@ -9,12 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - run: dotnet restore
-      - run: dotnet build --configuration Release --no-restore -warnaserror
-      - run: dotnet test --no-build
-      - run: dotnet pack --configuration Release -o Release -p:PackageVersion=${GITHUB_REF/refs\/tags\/v/''}
-      - run: dotnet nuget push Release/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json -k ${NUGET_AUTH_TOKEN}
+      - run: dotnet build --configuration Release --no-restore --warnaserror
+      - run: dotnet pack --configuration Release -o out/Release -p:PackageVersion=${GITHUB_REF/refs\/tags\/v/''}
+      - run: dotnet nuget push out/Release/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json -k ${NUGET_AUTH_TOKEN}
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,12 @@
-# Compiled code
+# Compiler outputs
 src/*/bin
-
-# Temp files created by the compiler
 src/*/obj
-
-# Release folder
-out
-Release
+src/*/out
+out/
 
 # IDEs
-.vs
 .vscode
 .idea
-.ionide
-.fake
 
-# Mac
+# macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Insurello.RabbitMqClient
 
-An F# wrapper around RabbitMq.Client version 5.
-
-[![Insurello](https://gitcdn.xyz/repo/insurello/elm-swedish-bank-account-number/master/insurello.svg)](https://jobb.insurello.se/departments/product-tech)
+An specialized F# wrapper around [RabbitMq.Client](https://github.com/rabbitmq/rabbitmq-dotnet-client).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Insurello.RabbitMqClient
 
-An specialized F# wrapper around [RabbitMq.Client](https://github.com/rabbitmq/rabbitmq-dotnet-client).
+A specialized F# wrapper around [RabbitMq.Client](https://github.com/rabbitmq/rabbitmq-dotnet-client).

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -31,7 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Insurello.AsyncExtra" Version="3.0.0" />
-    <PackageReference Include="RabbitMq.Client" Version="5.1.2" />
+    <PackageReference Include="RabbitMq.Client" Version="7.2.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Insurello.RabbitMqClient</PackageId>
     <Authors>Insurello</Authors>
     <Company>Insurello</Company>
@@ -22,24 +22,16 @@
   <ItemGroup>
     <!-- PrivateAssets="All" prevents consuming projects of this NuGet package from attempting to install SourceLink.
          It's only used while building. -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="MqClient.fs" />
+    <Compile Include="RabbitMqClient.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Insurello.AsyncExtra" Version="3.0.0" />
     <PackageReference Include="RabbitMq.Client" Version="7.2.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <!-- Pin FSharp.Core package to minimum supported 6.0.0
-     https://github.com/dotnet/fsharp/blob/main/docs/fsharp-core-notes.md
-     -->
-    <PackageReference Update="FSharp.Core" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -1,18 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+  
     <PackageId>Insurello.RabbitMqClient</PackageId>
-    <Authors>Insurello</Authors>
-    <Company>Insurello</Company>
-    <PackageDescription>F# wrapper around RabbitMq.Client</PackageDescription>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/insurello/Insurello.RabbitMqClient</RepositoryUrl>
+    <PackageDescription>An specialized F# wrapper around RabbitMq.Client</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
+    <Authors>Insurello</Authors>
+    <Company>Insurello</Company>
+
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/insurello/Insurello.RabbitMqClient</RepositoryUrl>
+  
     <!-- Source Link configuration -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedSources>true</EmbedSources>
+
     <!-- Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
 
@@ -20,18 +23,32 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- PrivateAssets="All" prevents consuming projects of this NuGet package from attempting to install SourceLink.
-         It's only used while building. -->
+    <!-- PrivateAssets="All" prevents consuming projects of this NuGet package from attempting to install SourceLink. It's only used while building. -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Enable opt-in warnings:
+    1182   = Unused variables
+    3389   = Implicit numeric widening
+    FS3560 = Copy and update changes all fields
+    -->
+    <WarnOn>1182,3389,FS3560</WarnOn>
+
+    <!-- Set enabled warnings as error during development:
+    FS0025 = Incomplete pattern matching
+    -->
+    <WarningsAsErrors>3389,FS0025</WarningsAsErrors>
+  </PropertyGroup>
+  
+  <!-- Source files -->
   <ItemGroup>
     <Compile Include="RabbitMqClient.fs" />
   </ItemGroup>
 
+  <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="RabbitMq.Client" Version="7.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
   </ItemGroup>
-
 </Project>

--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   
     <PackageId>Insurello.RabbitMqClient</PackageId>
-    <PackageDescription>An specialized F# wrapper around RabbitMq.Client</PackageDescription>
+    <PackageDescription>A specialized F# wrapper around RabbitMq.Client</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <Authors>Insurello</Authors>

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -902,7 +902,6 @@ module MqClient =
               OnUnregistered =
 
                   fun event ->
-                      printfn $"{name} OnUnregistered"
                       // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
                       if event.replyCode <> Constants.ReplySuccess then
                           logger.LogError(
@@ -921,7 +920,6 @@ module MqClient =
 
               OnShutdown =
                   fun event ->
-                      printfn $"{name} OnShutdown"
                       // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
                       if event.replyCode <> Constants.ReplySuccess then
                           logger.LogError(

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -1,5 +1,8 @@
 namespace Insurello.RabbitMqClient
 
+open System.Linq
+open Microsoft.Extensions.Logging
+
 [<RequireQualifiedAccess>]
 module MqClient =
 
@@ -10,12 +13,17 @@ module MqClient =
 
     type private ExceptionCallback = System.Exception -> string -> IConnection -> unit
 
-    type private ModelData =
-        { channelConsumer: AsyncEventingBasicConsumer
-          rpcConsumer: AsyncEventingBasicConsumer
-          pendingRequests: System.Collections.Concurrent.ConcurrentDictionary<string, Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource>
-          connection: IConnection
-          mutable ignoreCallbacksWhileClosing: bool }
+    type private ModelData = {
+        channelConsumer: AsyncEventingBasicConsumer
+        rpcConsumer: AsyncEventingBasicConsumer
+        pendingRequests:
+            System.Collections.Concurrent.ConcurrentDictionary<
+                string,
+                Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource
+             >
+        connection: IConnection
+        mutable ignoreCallbacksWhileClosing: bool
+    }
 
     and Message<'event> = private Message of 'event * ModelData
 
@@ -41,27 +49,29 @@ module MqClient =
         | DefaultToTen
         | Count of int
 
-    type Callbacks =
-        { OnReceived: ReceivedMessage -> Async<unit>
-          OnRegistered: ConsumerEventArgs Message -> Async<unit>
-          OnUnregistered: ConsumerEventArgs Message -> Async<unit>
-          OnConsumerCancelled: ConsumerEventArgs Message -> Async<unit>
-          OnShutdown: ShutdownEventArgs Message -> Async<unit> }
+    type Callbacks = {
+        OnReceived: ReceivedMessage -> Async<unit>
+        OnRegistered: ConsumerEventArgs Message -> Async<unit>
+        OnUnregistered: ConsumerEventArgs Message -> Async<unit>
+        OnConsumerCancelled: ConsumerEventArgs Message -> Async<unit>
+        OnShutdown: ShutdownEventArgs Message -> Async<unit>
+    }
 
     type Topology = QueueTopology list
 
-    and QueueTopology =
-        { Queue: string
-          BindToExchange: string option
-          ConsumeCallbacks: Callbacks
-          MessageTimeToLive: int option
-          QueueType: QueueType }
+    and QueueTopology = {
+        Queue: string
+        BindToExchange: string option
+        ConsumeCallbacks: Callbacks
+        MessageTimeToLive: int option
+        QueueType: QueueType
+    }
 
     and QueueType =
         | Classic
         | Quorum
 
-    [<RequireQualifiedAccessAttribute>]
+    [<RequireQualifiedAccess>]
     type PublishResult =
         | Acked
         | Nacked
@@ -80,22 +90,43 @@ module MqClient =
         | Generate
         | Id of string
 
-    type PublishMessage =
-        { CorrelationId: CorrelationId
-          Headers: Map<string, string>
-          Content: Content }
+    type PublishMessage = {
+        CorrelationId: CorrelationId
+        Headers: Map<string, string>
+        Content: Content
+    }
 
-    type private ChannelConfig =
-        { withConfirmSelect: bool
-          prefetchCount: uint16 }
+    type private ChannelConfig = {
+        withConfirmSelect: bool
+        prefetchCount: uint16
+    }
 
+    type ConnectionConfig = {
+        connectionName: string
+        endpoints: List<AmqpTcpEndpoint>
+        username: string
+        password: string
+        onConnectionShutdown: OnConnectionShutdown
+    }
+
+    and OnConnectionShutdown = OnConnectionShutdownEvent -> unit
+
+    and OnConnectionShutdownEvent = {
+        connectionName: string
+        replyCode: int
+        replyText: string
+    }
+
+    type CloseConnection = unit -> unit
+
+    let private connectionCloseTimeout = System.TimeSpan.FromSeconds 15.0
 
     let private contentTypeStringFromContent: Content -> string =
         function
         | Json _ -> "application/json"
         | Binary _ -> "application/octet-stream"
 
-    let private bodyFromContent: Content -> byte [] =
+    let private bodyFromContent: Content -> byte[] =
         function
         | Json jsonContent -> System.Text.Encoding.UTF8.GetBytes jsonContent
         | Binary binaryContent -> binaryContent
@@ -112,67 +143,70 @@ module MqClient =
             | null -> Error "Missing message_id property."
             | messageId -> Ok messageId
 
-    let extractReplyProperties: Message<BasicDeliverEventArgs>
-        -> Result<{| ReplyTo: string
-                     CorrelationId: string |}, string> =
+    let extractReplyProperties
+        : Message<BasicDeliverEventArgs>
+              -> Result<
+                  {|
+                      ReplyTo: string
+                      CorrelationId: string
+                  |},
+                  string
+               > =
         fun (Message (event, _)) ->
             event
             |> extractReplyTo
             |> Result.bind (fun replyTo ->
                 extractMesssageId event
-                |> Result.map (fun messageId ->
-                    {| ReplyTo = replyTo
-                       CorrelationId = messageId |}))
+                |> Result.map (fun messageId -> {|
+                    ReplyTo = replyTo
+                    CorrelationId = messageId
+                |})
+            )
 
     let routingKeyFromMessage: ReceivedMessage -> string =
         fun (Message (event, _)) -> event.RoutingKey
 
     let private asTask: ModelData -> 'event -> (Message<'event> -> Async<unit>) -> System.Threading.Tasks.Task =
         fun model event callback ->
-            async { do! callback (Message(event, model)) }
-            |> Async.StartAsTask
-            :> System.Threading.Tasks.Task
+            async { do! callback (Message (event, model)) } |> Async.StartAsTask :> System.Threading.Tasks.Task
 
-    let private consumeQueue: Model -> string -> QueueTopology -> Model =
+    let private consumeQueue: Model -> string -> QueueTopology -> Async<Model> =
         fun (Model model) uniqueTag queueTopology ->
 
             let consumerTag = queueTopology.Queue + "-consumer-" + uniqueTag
 
             let doNothingTask: unit -> System.Threading.Tasks.Task =
-                (fun () -> async.Return() |> Async.StartAsTask :> System.Threading.Tasks.Task)
+                (fun () -> async.Return () |> Async.StartAsTask :> System.Threading.Tasks.Task)
 
-            model.channelConsumer.add_Received (fun _sender event ->
+            model.channelConsumer.add_ReceivedAsync (fun _sender event ->
                 if event.ConsumerTag = consumerTag then
                     asTask model event queueTopology.ConsumeCallbacks.OnReceived
                 else
-                    doNothingTask ())
+                    doNothingTask ()
+            )
 
-            model.channelConsumer.add_Registered (fun _sender event ->
-                if event.ConsumerTag = consumerTag then
+            model.channelConsumer.add_RegisteredAsync (fun _sender event ->
+                if event.ConsumerTags.Contains consumerTag then
                     asTask model event queueTopology.ConsumeCallbacks.OnRegistered
                 else
-                    doNothingTask ())
+                    doNothingTask ()
+            )
 
-            model.channelConsumer.add_Unregistered (fun _sender event ->
-                if event.ConsumerTag = consumerTag then
+            model.channelConsumer.add_UnregisteredAsync (fun _sender event ->
+                if event.ConsumerTags.Contains consumerTag then
                     asTask model event queueTopology.ConsumeCallbacks.OnUnregistered
                 else
-                    doNothingTask ())
+                    doNothingTask ()
+            )
 
-            model.channelConsumer.add_Shutdown (fun _sender event ->
+            model.channelConsumer.add_ShutdownAsync (fun _sender event ->
                 if not model.ignoreCallbacksWhileClosing then
                     asTask model event queueTopology.ConsumeCallbacks.OnShutdown
                 else
-                    doNothingTask ())
+                    doNothingTask ()
+            )
 
-            model.channelConsumer.add_ConsumerCancelled (fun _sender event ->
-                if event.ConsumerTag = consumerTag
-                   && not model.ignoreCallbacksWhileClosing then
-                    asTask model event queueTopology.ConsumeCallbacks.OnConsumerCancelled
-                else
-                    doNothingTask ())
-
-            model.channelConsumer.Model.BasicConsume(
+            model.channelConsumer.Channel.BasicConsumeAsync (
                 queue = queueTopology.Queue,
                 autoAck = false,
                 consumerTag = consumerTag,
@@ -181,9 +215,8 @@ module MqClient =
                 arguments = null,
                 consumer = model.channelConsumer
             )
-            |> ignore
-
-            Model model
+            |> Async.AwaitTask
+            |> Async.map (fun _ -> Model model)
 
     let private nonNullString: string -> string =
         fun str ->
@@ -191,44 +224,84 @@ module MqClient =
             | true -> ""
             | false -> str
 
-    let private connectionFactory: System.Uri -> ConnectionFactory =
-        fun uri -> ConnectionFactory(DispatchConsumersAsync = true, AutomaticRecoveryEnabled = false, Uri = uri)
+    /// If the connection is unexpectedly closed the system will exit with error code 13.
+    let terminateOnUnexpectedShutdown (logger: ILogger) : OnConnectionShutdown =
+        fun event ->
+            // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+            if event.replyCode = Constants.ReplySuccess then
+                logger.LogWarning ("Closing RabbitMQ connection {connectionName}", event.connectionName)
 
-    let private createConnection: string -> IConnectionFactory -> IConnection =
-        fun clientProvidedName factory ->
-            factory.CreateConnection(clientProvidedName = nonNullString clientProvidedName)
+            else if event.replyCode <> Constants.ReplySuccess then
+                logger.LogError (
+                    "Got unexpected event `Shutdown` on connection {connectionName}. {replyCode} - {replyText}. Will terminate the process",
+                    event.connectionName,
+                    event.replyCode,
+                    event.replyText
+                )
 
-    let private connect: string -> System.Uri -> Result<IConnection, string> =
-        fun nameOfClient uri ->
+                exit 13 // TODO: 13?
+
+    let private connect (connectionConfig: ConnectionConfig) : Async<Result<IConnection, string>> =
+        task {
             try
-                connectionFactory uri
-                |> createConnection (nonNullString nameOfClient)
-                |> Ok
-            with
-            | :? BrokerUnreachableException as ex -> Error ex.Message
+                let factory =
+                    ConnectionFactory (
+                        AutomaticRecoveryEnabled = false,
 
-            | :? System.ArgumentException as ex -> Error ex.Message
+                        RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
+                        VirtualHost = "quorum-vhost",
 
-    let private closeConnection: int -> IConnection -> unit =
+                        UserName = connectionConfig.username,
+                        Password = connectionConfig.password
+                    )
+
+                let! connection =
+                    factory.CreateConnectionAsync (
+                        endpoints = connectionConfig.endpoints,
+                        clientProvidedName = connectionConfig.connectionName
+                    )
+
+                connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
+                    task {
+                        connectionConfig.onConnectionShutdown {
+                            connectionName = connectionConfig.connectionName
+                            replyCode = int eventArgs.ReplyCode
+                            replyText = eventArgs.ReplyText
+                        }
+                    }
+                )
+
+                return Ok connection
+
+            with exn ->
+                return Error $"%s{connectionConfig.connectionName}: Failed to connect to RabbitMQ: %s{string exn}"
+        }
+        |> Async.AwaitTask
+
+    let private closeConnection: float -> IConnection -> unit =
         fun timeout connection ->
             if connection.IsOpen then
-                // Connection seems to be locked when this function is called from an exception raised in MqClient.
-                // Make the call asynchrounous so this thread don't block the call.
-                Async.Start(async { connection.Close(timeout) })
+                connection.CloseAsync (System.TimeSpan.FromMilliseconds timeout)
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
             else
                 ()
 
     let private closeRpcConsumer: Model -> unit =
         fun (Model model) ->
-            if model.rpcConsumer.Model.IsOpen then
-                model.rpcConsumer.Model.Close()
+            if model.rpcConsumer.Channel.IsOpen then
+                model.rpcConsumer.Channel.CloseAsync ()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
             else
                 ()
 
     let private closeChannelConsumer: Model -> unit =
         fun (Model model) ->
-            if model.channelConsumer.Model.IsOpen then
-                model.channelConsumer.Model.Close()
+            if model.channelConsumer.Channel.IsOpen then
+                model.channelConsumer.Channel.CloseAsync ()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
             else
                 ()
 
@@ -244,133 +317,153 @@ module MqClient =
 
             closeChannelConsumer (Model model)
             closeRpcConsumer (Model model)
-            closeConnection 0 model.connection
+            closeConnection 0.0 model.connection
 
-    let private createChannel: ChannelConfig -> ExceptionCallback -> IConnection -> Result<IModel, string> =
-        fun config exCallback connection ->
-            try
-                let model = connection.CreateModel()
-                model.BasicQos(uint32 0, config.prefetchCount, false)
+    let private createChannel: ChannelConfig -> IConnection -> AsyncResult<IChannel, string> =
+        fun config connection ->
+            task {
+                try
+                    let! channel =
+                        connection.CreateChannelAsync (
+                            CreateChannelOptions (
+                                publisherConfirmationsEnabled = config.withConfirmSelect,
+                                publisherConfirmationTrackingEnabled = false
+                            )
+                        )
 
-                if config.withConfirmSelect then
-                    model.ConfirmSelect()
+                    do! channel.BasicQosAsync (uint32 0, config.prefetchCount, false)
 
-                model.CallbackException
-                |> Event.add (fun event ->
-                    let (hasContext, context) = event.Detail.TryGetValue "context"
+                    channel.add_CallbackExceptionAsync (fun a b ->
+                        task {
+                            do!
+                                connection.AbortAsync (
+                                    uint16 Constants.ChannelError,
+                                    "RabbitMqClient.Consumer: Unhandled channel exception, closing connection",
+                                    connectionCloseTimeout
+                                )
+                        }
+                    )
 
-                    exCallback
-                        event.Exception
-                        (if hasContext then
-                             context.ToString()
-                         else
-                             "")
-                        connection)
+                    return Ok channel
+                with :? AlreadyClosedException as ex ->
+                    return Error ex.Message
+            }
+            |> Async.AwaitTask
 
-                Ok model
-            with
-            | :? AlreadyClosedException as ex -> Error ex.Message
-
-    let private declareQueue: Model -> QueueTopology -> Result<QueueTopology, string> =
+    let private declareQueue: Model -> QueueTopology -> AsyncResult<QueueTopology, string> =
         fun (Model model) queueTopology ->
             let name = nonNullString queueTopology.Queue
 
             let arguments =
                 dict (
-                    [ "x-queue-type",
-                      (match queueTopology.QueueType with
-                       | Quorum -> "quorum"
-                       | Classic -> "classic")
-                      :> obj ]
+                    [
+                        "x-queue-type",
+                        (match queueTopology.QueueType with
+                         | Quorum -> "quorum"
+                         | Classic -> "classic")
+                        :> obj
+                    ]
                     @ (queueTopology.MessageTimeToLive
                        |> Option.map (fun ttl -> [ ("x-message-ttl", ttl :> obj) ])
                        |> Option.defaultValue [])
                 )
 
             try
-                model.channelConsumer.Model.QueueDeclare(
+                model.channelConsumer.Channel.QueueDeclareAsync (
                     queue = name,
                     durable = true,
                     exclusive = false,
                     autoDelete = false,
                     arguments = arguments
                 )
-                |> ignore
+                |> Async.AwaitTask
+                |> Async.map (fun _ -> Ok queueTopology)
+            with :? OperationInterruptedException as ex ->
+                Async.singleton (Error ex.Message)
 
-                Ok queueTopology
-            with
-            | :? OperationInterruptedException as ex -> Error ex.Message
-
-    let private bindQueueToExchange: Model -> QueueTopology -> Result<QueueTopology, string> =
+    let private bindQueueToExchange: Model -> QueueTopology -> AsyncResult<QueueTopology, string> =
         fun (Model model) queueTopology ->
             try
                 match queueTopology.BindToExchange with
                 | Some exchangeName ->
-                    model.channelConsumer.Model.QueueBind(
+                    model.channelConsumer.Channel.QueueBindAsync (
                         queue = queueTopology.Queue,
                         exchange = nonNullString exchangeName,
                         routingKey = "*",
                         arguments = null
                     )
-                    |> ignore
-                | None -> ()
+                    |> Async.AwaitTask
+                    |> Async.map (fun () -> Ok queueTopology)
 
-                Ok queueTopology
-            with
-            | ex -> Error ex.Message
+                | None -> Async.singleton (Ok queueTopology)
+            with ex ->
+                Async.singleton (Error ex.Message)
 
-    let private dictRemoveMutable: 'key
-        -> System.Collections.Concurrent.ConcurrentDictionary<'key, 'value>
-        -> 'value option =
+    let private dictRemoveMutable
+        : 'key -> System.Collections.Concurrent.ConcurrentDictionary<'key, 'value> -> 'value option =
         fun key dict ->
             match dict.TryRemove key with
             | true, value -> Some value
             | _ -> None
 
-    let private initReplyQueue: Model -> Model =
+    let private initReplyQueue: Model -> Async<Model> =
         fun (Model model) ->
             let queueName = "amq.rabbitmq.reply-to"
 
-            let consumerTag =
-                queueName
-                + "-consumer-"
-                + System.Guid.NewGuid().ToString()
+            let consumerTag = queueName + "-consumer-" + System.Guid.NewGuid().ToString ()
 
             let onReceived: ReceivedMessage -> Async<unit> =
-                (fun ((Message (event, _)) as message) ->
+                (fun (Message (event, _) as message) ->
                     let correlationId = event.BasicProperties.CorrelationId
 
                     match dictRemoveMutable correlationId model.pendingRequests with
-                    | Some tcs -> tcs.TrySetResult(Ok message) |> ignore
+                    | Some tcs -> tcs.TrySetResult (Ok message) |> ignore
 
                     | None -> ()
 
-                    async.Return())
+                    async.Return ()
+                )
 
-            model.rpcConsumer.add_Received (fun _sender event -> asTask model event onReceived)
+            model.rpcConsumer.add_ReceivedAsync (fun _sender event -> asTask model event onReceived)
 
-            model.rpcConsumer.add_Registered (fun _sender event -> asTask model event (fun _ -> async.Return()))
+            model.rpcConsumer.add_RegisteredAsync (fun _sender event -> asTask model event (fun _ -> async.Return ()))
 
-            model.rpcConsumer.add_Unregistered (fun _sender event ->
-                asTask model event (fun _ ->
-                    failwith "Got Unregistered event on rpc channel"
-                    async.Return()))
+            model.rpcConsumer.add_UnregisteredAsync (fun _sender event ->
+                asTask
+                    model
+                    event
+                    (fun _ ->
+                        failwith "Got Unregistered event on rpc channel"
+                        async.Return ()
+                    )
+            )
 
-            model.rpcConsumer.add_Shutdown (fun _sender event ->
-                asTask model event (fun _ ->
-                    if model.ignoreCallbacksWhileClosing then
-                        async.Return()
-                    else
-                        failwith "Got Shutdown event on rpc channel"))
+            model.rpcConsumer.add_ShutdownAsync (fun _sender event ->
+                asTask
+                    model
+                    event
+                    (fun _ ->
+                        if model.ignoreCallbacksWhileClosing then
+                            async.Return ()
+                        else
+                            failwith "Got Shutdown event on rpc channel"
+                    )
+            )
 
-            model.rpcConsumer.add_ConsumerCancelled (fun _sender event ->
-                asTask model event (fun _ ->
-                    if model.ignoreCallbacksWhileClosing then
-                        async.Return()
-                    else
-                        failwith "Got ConsumerCancelled event on rpc channel"))
+            // TODO: This doesn't exist
+            // model.rpcConsumer.add_ConsumerCancelled (fun _sender event ->
+            //     asTask
+            //         model
+            //         event
+            //         (fun _ ->
+            //             if model.ignoreCallbacksWhileClosing then
+            //                 async.Return ()
+            //             else
+            //                 failwith "Got ConsumerCancelled event on rpc channel"
+            //         )
+            // )
 
-            model.rpcConsumer.Model.BasicConsume(
+            model.rpcConsumer.Channel.BasicConsumeAsync (
                 queue = queueName,
                 autoAck = true, // Must be true for direct-reply-to
                 consumerTag = consumerTag,
@@ -379,68 +472,82 @@ module MqClient =
                 arguments = null,
                 consumer = model.rpcConsumer
             )
-            |> ignore
+            |> Async.AwaitTask
+            |> Async.map (fun _ -> Model model)
 
-            Model model
-
-    let private createBasicReturnEventHandler: string
-        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-        -> System.EventHandler<BasicReturnEventArgs> =
+    let private createBasicReturnEventHandler
+        : string
+              -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
+              -> AsyncEventHandler<BasicReturnEventArgs> =
         fun messageId tcs ->
-            System.EventHandler<BasicReturnEventArgs> (fun _ args ->
-                if args.BasicProperties.MessageId = messageId then
-                    tcs.TrySetResult(
-                        PublishResult.ReturnError(
-                            sprintf
-                                "Failed to publish to queue: ReplyCode: %i, ReplyText: %s, Exchange: %s, RoutingKey: %s"
-                                args.ReplyCode
-                                args.ReplyText
-                                args.Exchange
-                                args.RoutingKey
+            AsyncEventHandler<BasicReturnEventArgs> (fun _ args ->
+                task {
+                    if args.BasicProperties.MessageId = messageId then
+                        tcs.TrySetResult (
+                            PublishResult.ReturnError
+                                $"Failed to publish to queue: ReplyCode: %i{args.ReplyCode}, ReplyText: %s{args.ReplyText}, Exchange: %s{args.Exchange}, RoutingKey: %s{args.RoutingKey}"
                         )
-                    )
-                    |> ignore
-                else
-                    ())
+                        |> ignore
+                    else
+                        ()
+                }
+            )
 
     /// <summary>Returns true if the publishSeqNo is confirmed.</summary>
+    /// <param name="publishSeqNo"></param>
+    /// <param name="deliveredPublishSeqNo"></param>
     /// <param name="multipleConfirms">If false, only one message is confirmed, if true, all messages with a lower or equal sequence number are confirmed.</param>
     let private isConfirmed (publishSeqNo: uint64) (deliveredPublishSeqNo: uint64) (multipleConfirms: bool) : bool =
         publishSeqNo = deliveredPublishSeqNo
-        || multipleConfirms
-           && publishSeqNo < deliveredPublishSeqNo
+        || multipleConfirms && publishSeqNo < deliveredPublishSeqNo
 
-    let private createBasicAckEventHandler: uint64
-        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-        -> System.EventHandler<BasicAckEventArgs> =
+    let private createBasicAckEventHandler
+        : uint64 -> System.Threading.Tasks.TaskCompletionSource<PublishResult> -> AsyncEventHandler<BasicAckEventArgs> =
         fun publishSeqNo tcs ->
-            System.EventHandler<BasicAckEventArgs> (fun _ args ->
-                if isConfirmed publishSeqNo args.DeliveryTag args.Multiple then
-                    tcs.TrySetResult PublishResult.Acked |> ignore
-                else
-                    ())
+            AsyncEventHandler<BasicAckEventArgs> (fun _ args ->
+                task {
+                    if isConfirmed publishSeqNo args.DeliveryTag args.Multiple then
+                        tcs.TrySetResult PublishResult.Acked |> ignore
+                    else
+                        ()
+                }
+            )
 
-    let private createBasicNackEventHandler: uint64
-        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-        -> System.EventHandler<BasicNackEventArgs> =
+    let private createBasicNackEventHandler
+        : uint64 -> System.Threading.Tasks.TaskCompletionSource<PublishResult> -> AsyncEventHandler<BasicNackEventArgs> =
         fun publishSeqNo tcs ->
-            System.EventHandler<BasicNackEventArgs> (fun _ args ->
-                if isConfirmed publishSeqNo args.DeliveryTag args.Multiple then
-                    tcs.TrySetResult PublishResult.Nacked |> ignore
-                else
-                    ())
+            AsyncEventHandler<BasicNackEventArgs> (fun _ args ->
+                task {
+                    if isConfirmed publishSeqNo args.DeliveryTag args.Multiple then
+                        tcs.TrySetResult PublishResult.Nacked |> ignore
+                    else
+                        ()
+                }
+            )
 
     let ackMessage: ReceivedMessage -> unit =
         fun (Message (event, model)) ->
-            model.channelConsumer.Model.BasicAck(deliveryTag = event.DeliveryTag, multiple = false)
+            model.channelConsumer.Channel
+                .BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false)
+                .AsTask ()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
 
     let nackMessage: ReceivedMessage -> unit =
         fun (Message (event, model)) ->
-            model.channelConsumer.Model.BasicNack(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
+            model.channelConsumer.Channel
+                .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
+                .AsTask ()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
 
     let nackMessageWithoutRequeue: ReceivedMessage -> unit =
         fun (Message (event, model)) ->
-            model.channelConsumer.Model.BasicNack(deliveryTag = event.DeliveryTag, multiple = false, requeue = false)
+            model.channelConsumer.Channel
+                .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = false)
+                .AsTask ()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
 
     /// <summary>As <see cref="MqClient.ackMessage">ackMessage</see> but wrapped with Async</summary>
     let ackMessageAsync: ReceivedMessage -> Async<unit> = ackMessage >> Async.singleton
@@ -453,7 +560,6 @@ module MqClient =
     let nackMessageWithoutRequeueAsync: ReceivedMessage -> Async<unit> =
         nackMessageWithoutRequeue >> Async.singleton
 
-
     let nackMessageWithDelay: System.TimeSpan -> ReceivedMessage -> Async<unit> =
         fun delay msg ->
             let clamp minValue maxValue value = value |> max minValue |> min maxValue
@@ -465,7 +571,8 @@ module MqClient =
             |> Async.Sleep
             |> Async.bind (fun () -> nackMessageAsync msg)
 
-    let messageBody: ReceivedMessage -> byte [] = fun (Message (event, _)) -> event.Body
+    let messageBody: ReceivedMessage -> byte[] =
+        fun (Message (event, _)) -> event.Body.ToArray ()
 
     let messageBodyAsString: ReceivedMessage -> RawBody =
         messageBody >> System.Text.Encoding.UTF8.GetString
@@ -485,12 +592,10 @@ module MqClient =
                         match object with
                         | :? array<byte> as byteArray ->
                             try
-                                GetHeaderResult.StringValue(System.Text.Encoding.UTF8.GetString byteArray)
-                            with
-                            | ex ->
-                                GetHeaderResult.ErrorConvertingHeaderValueToString(
+                                GetHeaderResult.StringValue (System.Text.Encoding.UTF8.GetString byteArray)
+                            with ex ->
+                                GetHeaderResult.ErrorConvertingHeaderValueToString
                                     $"Couldn't convert to string. Reason: %s{ex.Message}"
-                                )
                         | _ -> GetHeaderResult.ErrorConvertingHeaderValueToString "Not a byte array"
                     | None -> GetHeaderResult.NotFound
 
@@ -500,190 +605,220 @@ module MqClient =
     let private uint16FromPrefetchConfig: PrefetchConfig -> Result<uint16, string> =
         fun prefetchCount ->
             match prefetchCount with
-            | PrefetchConfig.DefaultToTen -> Ok(uint16 10)
+            | PrefetchConfig.DefaultToTen -> Ok (uint16 10)
             | PrefetchConfig.Count count ->
                 if count >= 0 then
-                    Ok(uint16 count)
+                    Ok (uint16 count)
                 else
                     Error "PrefetchCount value must be a non-negative number"
 
-    let init: LogError -> string -> System.Uri -> PrefetchConfig -> (Model -> Topology) -> Result<Model, string> =
-        fun logError nameOfClient uri prefetchConfig getTopology ->
+    let init: ConnectionConfig -> PrefetchConfig -> (Model -> Topology) -> AsyncResult<Model * CloseConnection, string> =
+        fun connectionConfig prefetchConfig getTopology ->
 
             prefetchConfig
             |> uint16FromPrefetchConfig
-            |> Result.bind (fun prefetchCount ->
-                connect nameOfClient uri
-                |> Result.bind (fun connection ->
-                    let exCallback =
-                        (fun ex context connection ->
-                            logError (ex, "Unhandled exception on channel in context {$c}", context)
-                            closeConnection 3000 connection)
-
+            |> AsyncResult.fromResult
+            |> AsyncResult.bind (fun prefetchCount ->
+                connect connectionConfig
+                |> AsyncResult.bind (fun connection ->
                     createChannel
-                        { withConfirmSelect = true
-                          prefetchCount = prefetchCount }
-                        exCallback
+                        {
+                            withConfirmSelect = true
+                            prefetchCount = prefetchCount
+                        }
                         connection
-                    |> Result.bind (fun channel ->
+                    |> AsyncResult.bind (fun channel ->
                         createChannel
-                            { withConfirmSelect = false
-                              prefetchCount = prefetchCount }
-                            exCallback
+                            {
+                                withConfirmSelect = false
+                                prefetchCount = prefetchCount
+                            }
                             connection
-                        |> Result.map (fun rpcChannel ->
+                        |> AsyncResult.map (fun rpcChannel ->
                             (connection,
-                             Model
-                                 { channelConsumer = AsyncEventingBasicConsumer channel
+                             Model {
+                                 channelConsumer = AsyncEventingBasicConsumer channel
 
-                                   rpcConsumer = AsyncEventingBasicConsumer rpcChannel
+                                 rpcConsumer = AsyncEventingBasicConsumer rpcChannel
 
-                                   pendingRequests =
-                                       System.Collections.Concurrent.ConcurrentDictionary<string, Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource>
-                                           ()
-                                   connection = connection
-                                   ignoreCallbacksWhileClosing = false }))))
-                |> Result.bind (fun (connection, model) ->
+                                 pendingRequests =
+                                     System.Collections.Concurrent.ConcurrentDictionary<
+                                         string,
+                                         Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource
+                                      > ()
+                                 connection = connection
+                                 ignoreCallbacksWhileClosing = false
+                             })
+                        )
+                    )
+                )
+                |> AsyncResult.bind (fun (connection, model) ->
                     let declareAQueue = declareQueue model
                     let bindAQueue = bindQueueToExchange model
 
-                    let consumeAQueue = consumeQueue model (System.Guid.NewGuid().ToString())
+                    let consumeAQueue = consumeQueue model (System.Guid.NewGuid().ToString ())
 
                     getTopology model
                     |> List.fold
                         (fun prevResult queueTopology ->
-                            Result.bind
+                            AsyncResult.bind
                                 (fun _ ->
                                     declareAQueue queueTopology
-                                    |> Result.bind bindAQueue
-                                    |> Result.map consumeAQueue)
-                                prevResult)
-                        (Ok model)
-                    |> Result.mapError (fun error ->
-                        closeConnection 3000 connection
-                        error)
-                    |> Result.map initReplyQueue))
+                                    |> AsyncResult.bind bindAQueue
+                                    |> AsyncResult.bind (consumeAQueue >> Async.map Ok)
+                                )
+                                prevResult
+                        )
+                        (AsyncResult.singleton model)
+                    |> AsyncResult.mapError (fun error ->
+                        closeConnection 3000.0 connection
+                        error
+                    )
+                    |> AsyncResult.bind (
+                        initReplyQueue
+                        >> Async.map (fun model ->
+                            Ok (
+                                model,
+                                (fun () ->
+                                    connection.AbortAsync connectionCloseTimeout
+                                    |> Async.AwaitTask
+                                    |> Async.RunSynchronously
+                                )
+                            )
+                        )
+                    )
+                )
+            )
 
     /// Will publish with confirm.
     let publishToQueue: Model -> System.TimeSpan -> string -> PublishMessage -> Async<PublishResult> =
         fun (Model model) timeout routingKey message ->
             async {
-                let tcs = System.Threading.Tasks.TaskCompletionSource<PublishResult>()
+                let tcs = System.Threading.Tasks.TaskCompletionSource<PublishResult> ()
 
-                use ct = new System.Threading.CancellationTokenSource(timeout)
+                use ct = new System.Threading.CancellationTokenSource (timeout)
 
                 use _ctr =
-                    ct.Token.Register(
+                    ct.Token.Register (
                         callback =
                             (fun () ->
-                                tcs.SetResult(
-                                    (sprintf
-                                        "Publish to queue '%s' timedout after %ss"
-                                        routingKey
-                                        (timeout.TotalSeconds.ToString()))
+                                tcs.SetResult (
+                                    $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString ()}s"
                                     |> PublishResult.Timeout
                                 )
-                                |> ignore),
+                            ),
                         useSynchronizationContext = false
                     )
 
-                let messageId = System.Guid.NewGuid().ToString()
+                let messageId = System.Guid.NewGuid().ToString ()
 
                 let basicReturnEventHandler = createBasicReturnEventHandler messageId tcs
 
-                model.channelConsumer.Model.BasicReturn.AddHandler basicReturnEventHandler
+                model.channelConsumer.Channel.add_BasicReturnAsync basicReturnEventHandler
 
-                let (basicAckEventHandler, basicNackEventHandler) =
-                    lock model (fun () ->
-                        let nextPublishSeqNo = model.channelConsumer.Model.NextPublishSeqNo
+                let! basicAckEventHandler, basicNackEventHandler =
+                    lock
+                        model
+                        (fun () ->
+                            async {
+                                let! nextPublishSeqNo =
+                                    model.channelConsumer.Channel.GetNextPublishSequenceNumberAsync().AsTask ()
+                                    |> Async.AwaitTask
 
-                        let basicAckEventHandler = createBasicAckEventHandler nextPublishSeqNo tcs
+                                let basicAckEventHandler = createBasicAckEventHandler nextPublishSeqNo tcs
 
-                        model.channelConsumer.Model.BasicAcks.AddHandler basicAckEventHandler
+                                model.channelConsumer.Channel.add_BasicAcksAsync basicAckEventHandler
 
-                        let basicNackEventHandler = createBasicNackEventHandler nextPublishSeqNo tcs
+                                let basicNackEventHandler = createBasicNackEventHandler nextPublishSeqNo tcs
 
-                        model.channelConsumer.Model.BasicNacks.AddHandler basicNackEventHandler
+                                model.channelConsumer.Channel.add_BasicNacksAsync basicNackEventHandler
 
-                        model.channelConsumer.Model.BasicPublish(
-                            exchange = "",
-                            routingKey = routingKey,
-                            mandatory = true,
-                            basicProperties =
-                                model.channelConsumer.Model.CreateBasicProperties(
-                                    ContentType = contentTypeStringFromContent message.Content,
-                                    Persistent = true,
-                                    MessageId = messageId,
-                                    CorrelationId =
-                                        (match message.CorrelationId with
-                                         | CorrelationId.Generate -> ""
-                                         | CorrelationId.Id correlationId -> correlationId),
-                                    Headers =
-                                        (message.Headers
-                                         |> Map.map (fun _ v -> v :> obj)
-                                         |> (Map.toSeq >> dict))
-                                ),
-                            body = bodyFromContent message.Content
+                                do!
+                                    model.channelConsumer.Channel
+                                        .BasicPublishAsync(
+                                            exchange = "",
+                                            routingKey = routingKey,
+                                            mandatory = true,
+                                            basicProperties =
+                                                BasicProperties (
+                                                    ContentType = contentTypeStringFromContent message.Content,
+                                                    Persistent = true,
+                                                    MessageId = messageId,
+                                                    CorrelationId =
+                                                        (match message.CorrelationId with
+                                                         | CorrelationId.Generate -> ""
+                                                         | CorrelationId.Id correlationId -> correlationId),
+                                                    Headers =
+                                                        (message.Headers
+                                                         |> Map.map (fun _ v -> v :> obj)
+                                                         |> (Map.toSeq >> dict))
+                                                ),
+                                            body = bodyFromContent message.Content
+                                        )
+                                        .AsTask ()
+                                    |> Async.AwaitTask
+
+                                return (basicAckEventHandler, basicNackEventHandler)
+                            }
                         )
-
-                        (basicAckEventHandler, basicNackEventHandler))
 
                 let! publishResult = tcs.Task |> (Async.AwaitTask >> Async.Catch)
 
-                model.channelConsumer.Model.BasicAcks.RemoveHandler basicAckEventHandler
+                model.channelConsumer.Channel.remove_BasicAcksAsync basicAckEventHandler
 
-                model.channelConsumer.Model.BasicNacks.RemoveHandler basicNackEventHandler
+                model.channelConsumer.Channel.remove_BasicNacksAsync basicNackEventHandler
 
-                model.channelConsumer.Model.BasicReturn.RemoveHandler basicReturnEventHandler
+                model.channelConsumer.Channel.remove_BasicReturnAsync basicReturnEventHandler
 
                 return
                     match publishResult with
                     | Choice1Of2 result -> result
 
-                    | Choice2Of2 reason -> PublishResult.Unknown(sprintf "Task cancelled: %A" reason)
+                    | Choice2Of2 reason -> PublishResult.Unknown $"Task cancelled: %A{reason}"
             }
-
 
     let replyToMessage: Model -> ReceivedMessage -> Map<string, string> -> Content -> Async<PublishResult> =
         fun (Model model) receivedMessage headers content ->
             receivedMessage
             |> extractReplyProperties
             |> AsyncResult.fromResult
-            |> Async.map (function
+            |> Async.bind (
+                function
                 | Ok replyProperties ->
                     let headers = Map.add "sequence_end" "true" headers // sequence_end is required by Rabbot clients (https://github.com/arobson/rabbot/issues/76)
 
-                    let (contentType, body) =
+                    let contentType, body =
                         match content with
                         | Json jsonContent -> ("application/json", System.Text.Encoding.UTF8.GetBytes jsonContent)
                         | Binary bytes -> ("application/octet-stream", bytes)
 
-                    let messageId = System.Guid.NewGuid().ToString()
+                    let messageId = System.Guid.NewGuid().ToString ()
 
-                    model.channelConsumer.Model.BasicPublish(
-                        exchange = "",
-                        routingKey = replyProperties.ReplyTo,
-                        // mandatory must be false when publishing to direct-reply-to queue https://www.rabbitmq.com/direct-reply-to.html#limitations
-                        mandatory = false,
-                        basicProperties =
-                            model.channelConsumer.Model.CreateBasicProperties(
-                                ContentType = contentType,
-                                Persistent = true,
-                                MessageId = messageId,
-                                CorrelationId = replyProperties.CorrelationId,
-                                Headers =
-                                    (headers
-                                     |> Map.map (fun _ v -> v :> obj)
-                                     |> (Map.toSeq >> dict))
-                            ),
-                        body = body
-                    )
+                    model.channelConsumer.Channel
+                        .BasicPublishAsync(
+                            exchange = "",
+                            routingKey = replyProperties.ReplyTo,
+                            // mandatory must be false when publishing to direct-reply-to queue https://www.rabbitmq.com/direct-reply-to.html#limitations
+                            mandatory = false,
+                            basicProperties =
+                                BasicProperties (
+                                    ContentType = contentType,
+                                    Persistent = true,
+                                    MessageId = messageId,
+                                    CorrelationId = replyProperties.CorrelationId,
+                                    Headers = (headers |> Map.map (fun _ v -> v :> obj) |> (Map.toSeq >> dict))
+                                ),
+                            body = body
+                        )
+                        .AsTask ()
+                    |> Async.AwaitTask
+                    |> Async.map (fun _ -> PublishResult.Acked)
 
-                    PublishResult.Acked
-                | Error errorMessage -> PublishResult.Unknown errorMessage)
+                | Error errorMessage -> Async.singleton (PublishResult.Unknown errorMessage)
+            )
 
     /// <summary>Make an RPC-call to a RabbitMq queue.</summary>
-    /// <param name="Model">MqClient model.</param>
+    /// <param name="Model">MqClient model.</param>#pragma warning disable 3390
     /// <param name="timeout">Seconds before timing out request.</param>
     /// <param name="routingKey">Routing key to publish message to.</param>
     /// <param name="message">Message to be published.</param>
@@ -692,50 +827,48 @@ module MqClient =
         fun (Model model) timeout routingKey message ->
             async {
                 let tcs =
-                    System.Threading.Tasks.TaskCompletionSource<Result<ReceivedMessage, string>>()
+                    System.Threading.Tasks.TaskCompletionSource<Result<ReceivedMessage, string>> ()
 
-                use ct = new System.Threading.CancellationTokenSource(timeout)
+                use ct = new System.Threading.CancellationTokenSource (timeout)
 
-                let messageId = System.Guid.NewGuid().ToString()
+                let messageId = System.Guid.NewGuid().ToString ()
 
                 use _ctr =
-                    ct.Token.Register(
+                    ct.Token.Register (
                         callback =
                             (fun () ->
-                                dictRemoveMutable messageId model.pendingRequests
-                                |> ignore
+                                dictRemoveMutable messageId model.pendingRequests |> ignore
 
-                                tcs.TrySetResult(
-                                    Error(
-                                        sprintf
-                                            "Publish to queue '%s' timedout after %ss"
-                                            routingKey
-                                            (timeout.TotalSeconds.ToString())
-                                    )
+                                tcs.TrySetResult (
+                                    Error
+                                        $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString ()}s"
                                 )
-                                |> ignore),
+                                |> ignore
+                            ),
                         useSynchronizationContext = false
                     )
 
                 try
-                    if model.pendingRequests.TryAdd(messageId, tcs) then
-                        model.rpcConsumer.Model.BasicPublish(
-                            exchange = "",
-                            routingKey = routingKey,
-                            mandatory = true,
-                            basicProperties =
-                                model.rpcConsumer.Model.CreateBasicProperties(
-                                    ContentType = contentTypeStringFromContent message.Content,
-                                    Persistent = false,
-                                    MessageId = messageId,
-                                    ReplyTo = "amq.rabbitmq.reply-to",
-                                    Headers =
-                                        (message.Headers
-                                         |> Map.map (fun _ v -> v :> obj)
-                                         |> (Map.toSeq >> dict))
-                                ),
-                            body = bodyFromContent message.Content
-                        )
+                    if model.pendingRequests.TryAdd (messageId, tcs) then
+                        do!
+                            model.rpcConsumer.Channel
+                                .BasicPublishAsync(
+                                    exchange = "",
+                                    routingKey = routingKey,
+                                    mandatory = true,
+                                    basicProperties =
+                                        BasicProperties (
+                                            ContentType = contentTypeStringFromContent message.Content,
+                                            Persistent = false,
+                                            MessageId = messageId,
+                                            ReplyTo = "amq.rabbitmq.reply-to",
+                                            Headers =
+                                                (message.Headers |> Map.map (fun _ v -> v :> obj) |> (Map.toSeq >> dict))
+                                        ),
+                                    body = bodyFromContent message.Content
+                                )
+                                .AsTask ()
+                            |> Async.AwaitTask
 
                         let! result = tcs.Task |> (Async.AwaitTask >> Async.Catch)
 
@@ -745,7 +878,7 @@ module MqClient =
 
                             | Choice2Of2 reason -> Error reason.Message
                     else
-                        return Error(sprintf "Duplicate message id: %s" messageId)
+                        return Error $"Duplicate message id: %s{messageId}"
 
                 with
                 | :? System.ArgumentNullException as ex -> return Error ex.Message
@@ -754,40 +887,40 @@ module MqClient =
             }
 
     /// <summary>Wrap callbacks with default implementation for OnRegistered,
-    /// OnUnregistered, OnConsumerCancelled, OnShutdown. If any message is recieved
+    /// OnUnregistered, OnConsumerCancelled, OnShutdown. If any message is received
     /// for OnConsumerCancelled or OnShutdown the system will exit with error code 9</summary>
-    /// <param name="LogError">Logger.</param>
-    /// <param name="ReceivedMessage">Callback that's called when a new message is recieved.</param>
+    /// <param name="logError">Logger.</param>
+    /// <param name="onReceived">Callback that's called when a new message is received.</param>
     /// <returns>Callbacks</returns>
     let terminateOnFailureWrapper: LogError -> (ReceivedMessage -> Async<unit>) -> Callbacks =
-        fun logError onReceived ->
-            { OnReceived =
+        fun logError onReceived -> {
+            OnReceived =
                 fun message ->
-                    // Somthing weird happens with exception handeling when not
-                    // using Async computational expression. Some exepctions are
-                    // silenty swollowed and never bubbles up.
+                    // Something weird happens with exception handling when not
+                    // using Async computational expression. Some exceptions are
+                    // silently swallowed and never bubbles up.
                     async {
                         try
                             do! onReceived message
-                        with
-                        | exn ->
-                            logError (exn, (sprintf "💥 Unexpected error. %A\nShutting down" exn), ())
+                        with exn ->
+                            logError (exn, $"💥 Unexpected error. %A{exn}\nShutting down", ())
                             exit 9
                     }
 
-              OnRegistered = fun _ -> Async.singleton ()
+            OnRegistered = fun _ -> Async.singleton ()
 
-              OnUnregistered =
-                  fun _ ->
-                      logError (null, "Got OnUnregistered event", ())
-                      exit 10
+            OnUnregistered =
+                fun _ ->
+                    logError (null, "Got OnUnregistered event", ())
+                    exit 10
 
-              OnConsumerCancelled =
-                  fun _ ->
-                      logError (null, "Got OnConsumerCancelled event", ())
-                      exit 11
+            OnConsumerCancelled =
+                fun _ ->
+                    logError (null, "Got OnConsumerCancelled event", ())
+                    exit 11
 
-              OnShutdown =
-                  fun _ ->
-                      logError (null, "Got OnShutdown event", ())
-                      exit 12 }
+            OnShutdown =
+                fun _ ->
+                    logError (null, "Got OnShutdown event", ())
+                    exit 12
+        }

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -237,7 +237,7 @@ module MqClient =
                     event.replyText
                 )
 
-                exit 13 // TODO: 13?
+                exit 13
 
     let private connect (connectionConfig: ConnectionConfig) : Async<Result<IConnection, string>> =
         task {
@@ -258,8 +258,6 @@ module MqClient =
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
-                        printfn $"Got ConnectionShutdownAsync event with eventArgs: {eventArgs.ReplyCode}"
-
                         connectionConfig.onConnectionShutdown
                             { connectionName = connectionConfig.connectionName
                               replyCode = int eventArgs.ReplyCode
@@ -658,15 +656,9 @@ module MqClient =
                             Ok(
                                 model,
                                 (fun () ->
-                                    printfn "Calling -> connection.AbortAsync connectionCloseTimeout"
-
                                     connection.AbortAsync connectionCloseTimeout
                                     |> Async.AwaitTask
-                                    |> Async.RunSynchronously
-
-                                    printfn "Done -> connection.AbortAsync connectionCloseTimeout"
-
-                                    )
+                                    |> Async.RunSynchronously)
                             ))
                     )))
 

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -1,236 +1,80 @@
-namespace Insurello.RabbitMqClient
+module Insurello.RabbitMqClient
 
-open System.Linq
 open Microsoft.Extensions.Logging
+open RabbitMQ.Client
+open RabbitMQ.Client.Events
+open System.Threading.Tasks
 
-[<RequireQualifiedAccess>]
-module MqClient =
+type Connection = private Connection of IConnection
 
-    open Insurello.AsyncExtra
-    open RabbitMQ.Client
-    open RabbitMQ.Client.Events
-    open RabbitMQ.Client.Exceptions
+let private connectionCloseTimeout = System.TimeSpan.FromSeconds 15.0
 
-    type private ExceptionCallback = System.Exception -> string -> IConnection -> unit
+module Connection =
 
-    type private ModelData =
-        { channelConsumer: AsyncEventingBasicConsumer
-          rpcConsumer: AsyncEventingBasicConsumer
-          pendingRequests: System.Collections.Concurrent.ConcurrentDictionary<string, Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource>
-          connection: IConnection
-          mutable ignoreCallbacksWhileClosing: bool }
+    type OnConnectionShutdown = OnConnectionShutdownEvent -> unit
 
-    and Message<'event> = private Message of 'event * ModelData
-
-    and ReceivedMessage = Message<BasicDeliverEventArgs>
-
-    type RawBody = string
-
-    type Model = private Model of ModelData
-
-    [<RequireQualifiedAccess>]
-    type GetHeaderResult =
-        | StringValue of string
-        | NotFound
-        | ErrorConvertingHeaderValueToString of string
-
-    /// <summary>
-    /// The maximum number of MQ messages to be fetched from queues and get processed at a time by the RabbitMQ client.
-    /// We recommend setting it to DefaultToTen if you don't know what you are doing.
-    /// </summary>
-    /// <returns>PrefetchConfig</returns>
-    [<RequireQualifiedAccess>]
-    type PrefetchConfig =
-        | DefaultToTen
-        | Count of int
-
-    type Callbacks =
-        { OnReceived: ReceivedMessage -> Async<unit>
-          OnRegistered: ConsumerEventArgs Message -> Async<unit>
-          OnUnregistered: UnregisteredEvent -> unit
-          OnConsumerCancelled: ConsumerEventArgs Message -> Async<unit>
-          OnShutdown: UnregisteredEvent -> unit }
-
-    and UnregisteredEvent =
-        { queueName: string
-          replyCode: int
-          replyText: string }
-
-    type Topology = QueueTopology list
-
-    and QueueTopology =
-        { Queue: string
-          BindToExchange: string option
-          ConsumeCallbacks: Callbacks
-          MessageTimeToLive: int option
-          QueueType: QueueType }
-
-    and QueueType =
-        | Classic
-        | Quorum
-
-    [<RequireQualifiedAccess>]
-    type PublishResult =
-        | Acked
-        | Nacked
-        | ReturnError of string
-        | Timeout of string
-        | Unknown of string
-
-    type LogError = exn * string * obj -> unit
-
-    type Content =
-        | Json of string
-        | Binary of byte array
-
-    [<RequireQualifiedAccess>]
-    type CorrelationId =
-        | Generate
-        | Id of string
-
-    type PublishMessage =
-        { CorrelationId: CorrelationId
-          Headers: Map<string, string>
-          Content: Content }
-
-    type private ChannelConfig =
-        { withConfirmSelect: bool
-          prefetchCount: uint16 }
-
-    type ConnectionConfig =
-        { connectionName: string
-          endpoints: List<AmqpTcpEndpoint>
-          onConnectionShutdown: OnConnectionShutdown }
-
-    and OnConnectionShutdown = OnConnectionShutdownEvent -> unit
-
-    and OnConnectionShutdownEvent =
-        { connectionName: string
-          replyCode: int
-          replyText: string }
+    and OnConnectionShutdownEvent = {
+        connectionName: string
+        replyCode: int
+        replyText: string
+    }
 
     type CloseConnection = unit -> unit
 
-    let private connectionCloseTimeout = System.TimeSpan.FromSeconds 15.0
+    let initAsync
+        (connectionName: string)
+        (endpoints: List<System.Uri>)
+        (onConnectionShutdown: OnConnectionShutdown)
+        : Async<Result<Connection * CloseConnection, string>> =
+        task {
+            try
+                let factory =
+                    ConnectionFactory (
+                        AutomaticRecoveryEnabled = false,
+                        RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
+                        VirtualHost = "quorum-vhost"
+                    )
 
-    let private contentTypeStringFromContent: Content -> string =
-        function
-        | Json _ -> "application/json"
-        | Binary _ -> "application/octet-stream"
+                let! connection =
+                    factory.CreateConnectionAsync (
+                        endpoints = List.map AmqpTcpEndpoint endpoints,
+                        clientProvidedName = connectionName
+                    )
 
-    let private bodyFromContent: Content -> byte [] =
-        function
-        | Json jsonContent -> System.Text.Encoding.UTF8.GetBytes jsonContent
-        | Binary binaryContent -> binaryContent
+                connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
+                    task {
+                        onConnectionShutdown {
+                            connectionName = connectionName
+                            replyCode = int eventArgs.ReplyCode
+                            replyText = eventArgs.ReplyText
+                        }
+                    }
+                )
 
-    let private extractReplyTo: BasicDeliverEventArgs -> Result<string, string> =
-        fun event ->
-            match event.BasicProperties.ReplyTo with
-            | null -> Error "Missing reply_to property."
-            | replyTo -> Ok replyTo
+                return
+                    Ok (
+                        Connection connection,
+                        (fun () ->
+                            connection.AbortAsync connectionCloseTimeout
+                            |> Async.AwaitTask
+                            |> Async.RunSynchronously
+                        )
+                    )
 
-    let private extractMesssageId: BasicDeliverEventArgs -> Result<string, string> =
-        fun event ->
-            match event.BasicProperties.MessageId with
-            | null -> Error "Missing message_id property."
-            | messageId -> Ok messageId
-
-    let extractReplyProperties: Message<BasicDeliverEventArgs>
-        -> Result<{| ReplyTo: string
-                     CorrelationId: string |}, string> =
-        fun (Message (event, _)) ->
-            event
-            |> extractReplyTo
-            |> Result.bind (fun replyTo ->
-                extractMesssageId event
-                |> Result.map (fun messageId ->
-                    {| ReplyTo = replyTo
-                       CorrelationId = messageId |}))
-
-    let routingKeyFromMessage: ReceivedMessage -> string =
-        fun (Message (event, _)) -> event.RoutingKey
-
-    let private asTask: ModelData -> 'event -> (Message<'event> -> Async<unit>) -> System.Threading.Tasks.Task =
-        fun model event callback ->
-            async { do! callback (Message(event, model)) }
-            |> Async.StartAsTask
-            :> System.Threading.Tasks.Task
-
-    let private consumeQueue: Model -> string -> QueueTopology -> Async<Model> =
-        fun (Model model) uniqueTag queueTopology ->
-
-            let consumerTag = queueTopology.Queue + "-consumer-" + uniqueTag
-
-            let doNothingTask: unit -> System.Threading.Tasks.Task =
-                (fun () -> async.Return() |> Async.StartAsTask :> System.Threading.Tasks.Task)
-
-            model.channelConsumer.add_ReceivedAsync (fun _sender event ->
-                if event.ConsumerTag = consumerTag then
-                    asTask model event queueTopology.ConsumeCallbacks.OnReceived
-                else
-                    doNothingTask ())
-
-            model.channelConsumer.add_RegisteredAsync (fun _sender event ->
-                if event.ConsumerTags.Contains consumerTag then
-                    asTask model event queueTopology.ConsumeCallbacks.OnRegistered
-                else
-                    doNothingTask ())
-
-            model.channelConsumer.add_UnregisteredAsync (fun _sender eventArgs ->
-                task {
-                    let shutdownReason = model.channelConsumer.ShutdownReason
-
-                    if eventArgs.ConsumerTags
-                       |> Array.contains consumerTag then
-                        let replyCode, replyText =
-                            if shutdownReason = null then
-                                0, "Missing ShutdownReason. Did the queue got deleted?"
-                            else
-                                int shutdownReason.ReplyCode, shutdownReason.ReplyText
-
-                        queueTopology.ConsumeCallbacks.OnUnregistered
-                            { queueName = queueTopology.Queue
-                              replyCode = replyCode
-                              replyText = replyText }
-                }
-
-            )
-
-            model.channelConsumer.add_ShutdownAsync (fun _sender event ->
-                task {
-                    queueTopology.ConsumeCallbacks.OnShutdown
-                        { queueName = queueTopology.Queue
-                          replyCode = int model.channelConsumer.ShutdownReason.ReplyCode
-                          replyText = model.channelConsumer.ShutdownReason.ReplyText }
-                })
-
-            model.channelConsumer.Channel.BasicConsumeAsync(
-                queue = queueTopology.Queue,
-                autoAck = false,
-                consumerTag = consumerTag,
-                noLocal = false,
-                exclusive = false,
-                arguments = null,
-                consumer = model.channelConsumer
-            )
-            |> Async.AwaitTask
-            |> Async.map (fun _ -> Model model)
-
-    let private nonNullString: string -> string =
-        fun str ->
-            match System.String.IsNullOrEmpty str with
-            | true -> ""
-            | false -> str
+            with exn ->
+                return Error $"%s{connectionName}: Failed to connect to RabbitMQ: %s{string exn}"
+        }
+        |> Async.AwaitTask
 
     /// If the connection is unexpectedly closed the system will exit with error code 13.
     let terminateOnUnexpectedShutdown (logger: ILogger) : OnConnectionShutdown =
         fun event ->
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
-                logger.LogWarning("Closing RabbitMQ connection {connectionName}", event.connectionName)
+                logger.LogWarning ("Closing RabbitMQ connection {connectionName}", event.connectionName)
 
             else if event.replyCode <> Constants.ReplySuccess then
-                logger.LogError(
+                logger.LogError (
                     "Got unexpected event `Shutdown` on connection {connectionName}. {replyCode} - {replyText}. Will terminate the process",
                     event.connectionName,
                     event.replyCode,
@@ -239,688 +83,521 @@ module MqClient =
 
                 exit 13
 
-    let private connect (connectionConfig: ConnectionConfig) : Async<Result<IConnection, string>> =
-        task {
-            try
-                let factory =
-                    ConnectionFactory(
-                        AutomaticRecoveryEnabled = false,
+module Consumer =
 
-                        RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
-                        VirtualHost = "quorum-vhost"
-                    )
+    type Model = private Consumer of AsyncEventingBasicConsumer
 
-                let! connection =
-                    factory.CreateConnectionAsync(
-                        endpoints = connectionConfig.endpoints,
-                        clientProvidedName = connectionConfig.connectionName
-                    )
+    type ReceivedMessage = private ReceivedMessage of BasicDeliverEventArgs * AsyncEventingBasicConsumer
 
-                connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
-                    task {
-                        connectionConfig.onConnectionShutdown
-                            { connectionName = connectionConfig.connectionName
-                              replyCode = int eventArgs.ReplyCode
-                              replyText = eventArgs.ReplyText }
-                    })
+    type Callbacks = {
+        onReceived: ReceivedMessage -> Async<unit>
+        onRegistered: string -> unit
+        onUnregistered: UnregisteredEvent -> unit
+        onShutdown: UnregisteredEvent -> unit
+    }
 
-                return Ok connection
+    and UnregisteredEvent = {
+        queueName: string
+        replyCode: int
+        replyText: string
+    }
 
-            with
-            | exn -> return Error $"%s{connectionConfig.connectionName}: Failed to connect to RabbitMQ: %s{string exn}"
-        }
+    and QueueConfig = {
+        queueName: string
+        bindToExchange: Option<string>
+        callbacks: Callbacks
+        messageTimeToLive: Option<int>
+        queueType: QueueType
+    }
+
+    and QueueType =
+        | Quorum
+        /// Deprecated. Use `Quorum` instead.
+        | Classic
+
+    /// The number of unacked messages to pre-fetch.
+    /// This also defines the number of possible messages to be nacking concurrently.
+    [<Struct>]
+    type QueuePrefetchCount = TenMessages
+
+    type ReplyMessage = {
+        headers: List<string * string>
+        body: ReplyBody
+    }
+
+    and ReplyBody = Json of string
+
+    let ackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
+        consumer.Channel
+            .BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false)
+            .AsTask ()
         |> Async.AwaitTask
 
-    let private closeConnection: float -> IConnection -> unit =
-        fun timeout connection ->
-            if connection.IsOpen then
-                connection.CloseAsync(System.TimeSpan.FromMilliseconds timeout)
-                |> Async.AwaitTask
-                |> Async.RunSynchronously
-            else
-                ()
+    let nackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
+        consumer.Channel
+            .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
+            .AsTask ()
+        |> Async.AwaitTask
 
-    let private closeRpcConsumer: Model -> unit =
-        fun (Model model) ->
-            if model.rpcConsumer.Channel.IsOpen then
-                model.rpcConsumer.Channel.CloseAsync()
-                |> Async.AwaitTask
-                |> Async.RunSynchronously
-            else
-                ()
-
-    let private closeChannelConsumer: Model -> unit =
-        fun (Model model) ->
-            if model.channelConsumer.Channel.IsOpen then
-                model.channelConsumer.Channel.CloseAsync()
-                |> Async.AwaitTask
-                |> Async.RunSynchronously
-            else
-                ()
-
-    /// <summary>
-    /// Gracefully closes the connection, the channel consumer and the rpc consumer.
-    /// </summary>
-    let close: Model -> unit =
-        fun (Model model) ->
-            // User has requested a graceful close. This will trigger callbacks that could lead to unexpected
-            // exceptions. This flag will ignore any callback calls from RabbitMQ Client.
-            // There is no way to undo the close.
-            model.ignoreCallbacksWhileClosing <- true
-
-            closeChannelConsumer (Model model)
-            closeRpcConsumer (Model model)
-            closeConnection 0.0 model.connection
-
-    let private createChannel: ChannelConfig -> IConnection -> AsyncResult<IChannel, string> =
-        fun config connection ->
-            task {
-                try
-                    let! channel =
-                        connection.CreateChannelAsync(
-                            CreateChannelOptions(
-                                publisherConfirmationsEnabled = config.withConfirmSelect,
-                                publisherConfirmationTrackingEnabled = false
-                            )
-                        )
-
-                    do! channel.BasicQosAsync(uint32 0, config.prefetchCount, false)
-
-                    channel.add_CallbackExceptionAsync (fun a b ->
-                        task {
-                            do!
-                                connection.AbortAsync(
-                                    uint16 Constants.ChannelError,
-                                    "RabbitMqClient.Consumer: Unhandled channel exception, closing connection",
-                                    connectionCloseTimeout
-                                )
-                        })
-
-                    return Ok channel
-                with
-                | :? AlreadyClosedException as ex -> return Error ex.Message
-            }
-            |> Async.AwaitTask
-
-    let private declareQueue: Model -> QueueTopology -> AsyncResult<QueueTopology, string> =
-        fun (Model model) queueTopology ->
-            let name = nonNullString queueTopology.Queue
-
-            let arguments =
-                dict (
-                    [ "x-queue-type",
-                      (match queueTopology.QueueType with
-                       | Quorum -> "quorum"
-                       | Classic -> "classic")
-                      :> obj ]
-                    @ (queueTopology.MessageTimeToLive
-                       |> Option.map (fun ttl -> [ ("x-message-ttl", ttl :> obj) ])
-                       |> Option.defaultValue [])
-                )
-
-            try
-                model.channelConsumer.Channel.QueueDeclareAsync(
-                    queue = name,
-                    durable = true,
-                    exclusive = false,
-                    autoDelete = false,
-                    arguments = arguments
-                )
-                |> Async.AwaitTask
-                |> Async.map (fun _ -> Ok queueTopology)
-            with
-            | :? OperationInterruptedException as ex -> Async.singleton (Error ex.Message)
-
-    let private bindQueueToExchange: Model -> QueueTopology -> AsyncResult<QueueTopology, string> =
-        fun (Model model) queueTopology ->
-            try
-                match queueTopology.BindToExchange with
-                | Some exchangeName ->
-                    model.channelConsumer.Channel.QueueBindAsync(
-                        queue = queueTopology.Queue,
-                        exchange = nonNullString exchangeName,
-                        routingKey = "*",
-                        arguments = null
-                    )
-                    |> Async.AwaitTask
-                    |> Async.map (fun () -> Ok queueTopology)
-
-                | None -> Async.singleton (Ok queueTopology)
-            with
-            | ex -> Async.singleton (Error ex.Message)
-
-    let private dictRemoveMutable: 'key
-        -> System.Collections.Concurrent.ConcurrentDictionary<'key, 'value>
-        -> 'value option =
-        fun key dict ->
-            match dict.TryRemove key with
-            | true, value -> Some value
-            | _ -> None
-
-    let private initReplyQueue: Model -> Async<Model> =
-        fun (Model model) ->
-            let queueName = "amq.rabbitmq.reply-to"
-
-            let consumerTag =
-                queueName
-                + "-consumer-"
-                + System.Guid.NewGuid().ToString()
-
-            let onReceived: ReceivedMessage -> Async<unit> =
-                (fun (Message (event, _) as message) ->
-                    let correlationId = event.BasicProperties.CorrelationId
-
-                    match dictRemoveMutable correlationId model.pendingRequests with
-                    | Some tcs -> tcs.TrySetResult(Ok message) |> ignore
-
-                    | None -> ()
-
-                    async.Return())
-
-            model.rpcConsumer.add_ReceivedAsync (fun _sender event -> asTask model event onReceived)
-
-            model.rpcConsumer.add_RegisteredAsync (fun _sender event -> asTask model event (fun _ -> async.Return()))
-
-            model.rpcConsumer.add_UnregisteredAsync (fun _sender event ->
-                asTask model event (fun _ ->
-                    failwith "Got Unregistered event on rpc channel"
-                    async.Return()))
-
-            model.rpcConsumer.add_ShutdownAsync (fun _sender event ->
-                asTask model event (fun _ ->
-                    if model.ignoreCallbacksWhileClosing then
-                        async.Return()
-                    else
-                        failwith "Got Shutdown event on rpc channel"))
-
-            // TODO: This doesn't exist
-            // model.rpcConsumer.add_ConsumerCancelled (fun _sender event ->
-            //     asTask
-            //         model
-            //         event
-            //         (fun _ ->
-            //             if model.ignoreCallbacksWhileClosing then
-            //                 async.Return ()
-            //             else
-            //                 failwith "Got ConsumerCancelled event on rpc channel"
-            //         )
-            // )
-
-            model.rpcConsumer.Channel.BasicConsumeAsync(
-                queue = queueName,
-                autoAck = true, // Must be true for direct-reply-to
-                consumerTag = consumerTag,
-                noLocal = false,
-                exclusive = false,
-                arguments = null,
-                consumer = model.rpcConsumer
-            )
-            |> Async.AwaitTask
-            |> Async.map (fun _ -> Model model)
-
-    let private createBasicReturnEventHandler: string
-        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-        -> AsyncEventHandler<BasicReturnEventArgs> =
-        fun messageId tcs ->
-            AsyncEventHandler<BasicReturnEventArgs> (fun _ args ->
-                task {
-                    if args.BasicProperties.MessageId = messageId then
-                        tcs.TrySetResult(
-                            PublishResult.ReturnError
-                                $"Failed to publish to queue: ReplyCode: %i{args.ReplyCode}, ReplyText: %s{args.ReplyText}, Exchange: %s{args.Exchange}, RoutingKey: %s{args.RoutingKey}"
-                        )
-                        |> ignore
-                    else
-                        ()
-                })
-
-    /// <summary>Returns true if the publishSeqNo is confirmed.</summary>
-    /// <param name="publishSeqNo"></param>
-    /// <param name="deliveredPublishSeqNo"></param>
-    /// <param name="multipleConfirms">If false, only one message is confirmed, if true, all messages with a lower or equal sequence number are confirmed.</param>
-    let private isConfirmed (publishSeqNo: uint64) (deliveredPublishSeqNo: uint64) (multipleConfirms: bool) : bool =
-        publishSeqNo = deliveredPublishSeqNo
-        || multipleConfirms
-           && publishSeqNo < deliveredPublishSeqNo
-
-    let private createBasicAckEventHandler: uint64
-        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-        -> AsyncEventHandler<BasicAckEventArgs> =
-        fun publishSeqNo tcs ->
-            AsyncEventHandler<BasicAckEventArgs> (fun _ args ->
-                task {
-                    if isConfirmed publishSeqNo args.DeliveryTag args.Multiple then
-                        tcs.TrySetResult PublishResult.Acked |> ignore
-                    else
-                        ()
-                })
-
-    let private createBasicNackEventHandler: uint64
-        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-        -> AsyncEventHandler<BasicNackEventArgs> =
-        fun publishSeqNo tcs ->
-            AsyncEventHandler<BasicNackEventArgs> (fun _ args ->
-                task {
-                    if isConfirmed publishSeqNo args.DeliveryTag args.Multiple then
-                        tcs.TrySetResult PublishResult.Nacked |> ignore
-                    else
-                        ()
-                })
-
-    let ackMessage: ReceivedMessage -> unit =
-        fun (Message (event, model)) ->
-            model
-                .channelConsumer
-                .Channel
-                .BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false)
-                .AsTask()
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
-
-    let nackMessage: ReceivedMessage -> unit =
-        fun (Message (event, model)) ->
-            model
-                .channelConsumer
-                .Channel
-                .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
-                .AsTask()
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
-
-    let nackMessageWithoutRequeue: ReceivedMessage -> unit =
-        fun (Message (event, model)) ->
-            model
-                .channelConsumer
-                .Channel
-                .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = false)
-                .AsTask()
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
-
-    /// <summary>As <see cref="MqClient.ackMessage">ackMessage</see> but wrapped with Async</summary>
-    let ackMessageAsync: ReceivedMessage -> Async<unit> = ackMessage >> Async.singleton
-
-    /// <summary>As <see cref="MqClient.nackMessage">nackMessage</see> but wrapped with Async</summary>
-    let nackMessageAsync: ReceivedMessage -> Async<unit> =
-        nackMessage >> Async.singleton
-
-    /// <summary>As <see cref="MqClient.nackMessageWithoutRequeue">nackMessageWithoutRequeue</see> but wrapped with Async</summary>
-    let nackMessageWithoutRequeueAsync: ReceivedMessage -> Async<unit> =
-        nackMessageWithoutRequeue >> Async.singleton
-
-    let nackMessageWithDelay: System.TimeSpan -> ReceivedMessage -> Async<unit> =
-        fun delay msg ->
-            let clamp minValue maxValue value = value |> max minValue |> min maxValue
-
-            delay.TotalMilliseconds
-            |> round
-            |> clamp 0.0 (float System.Int32.MaxValue)
-            |> int
-            |> Async.Sleep
-            |> Async.bind (fun () -> nackMessageAsync msg)
-
-    let messageBody: ReceivedMessage -> byte [] =
-        fun (Message (event, _)) -> event.Body.ToArray()
-
-    let messageBodyAsString: ReceivedMessage -> RawBody =
-        messageBody >> System.Text.Encoding.UTF8.GetString
-
-    /// <summary>Given a ReceivedMessage and a `key` tries to find the Header value and convert it to a string.</summary>
-    /// <returns>GetHeaderResult</returns>
-    let getHeaderAsString: ReceivedMessage -> string -> GetHeaderResult =
-        fun receivedMessage key ->
-            match receivedMessage with
-            | Message (basicDeliverEventArgs, _) ->
-                basicDeliverEventArgs.BasicProperties.Headers
-                |> Seq.map (|KeyValue|)
-                |> Map.ofSeq
-                |> Map.tryFind key
-                |> function
-                    | Some (object: obj) ->
-                        match object with
-                        | :? array<byte> as byteArray ->
-                            try
-                                GetHeaderResult.StringValue(System.Text.Encoding.UTF8.GetString byteArray)
-                            with
-                            | ex ->
-                                GetHeaderResult.ErrorConvertingHeaderValueToString
-                                    $"Couldn't convert to string. Reason: %s{ex.Message}"
-                        | _ -> GetHeaderResult.ErrorConvertingHeaderValueToString "Not a byte array"
-                    | None -> GetHeaderResult.NotFound
-
-    let messageId: ReceivedMessage -> string =
-        fun (Message (event, _)) -> event.BasicProperties.MessageId
-
-    let private uint16FromPrefetchConfig: PrefetchConfig -> Result<uint16, string> =
-        fun prefetchCount ->
-            match prefetchCount with
-            | PrefetchConfig.DefaultToTen -> Ok(uint16 10)
-            | PrefetchConfig.Count count ->
-                if count >= 0 then
-                    Ok(uint16 count)
-                else
-                    Error "PrefetchCount value must be a non-negative number"
-
-    let init: ConnectionConfig -> PrefetchConfig -> (Model -> Topology) -> AsyncResult<Model * CloseConnection, string> =
-        fun connectionConfig prefetchConfig getTopology ->
-
-            prefetchConfig
-            |> uint16FromPrefetchConfig
-            |> AsyncResult.fromResult
-            |> AsyncResult.bind (fun prefetchCount ->
-                connect connectionConfig
-                |> AsyncResult.bind (fun connection ->
-                    createChannel
-                        { withConfirmSelect = true
-                          prefetchCount = prefetchCount }
-                        connection
-                    |> AsyncResult.bind (fun channel ->
-                        createChannel
-                            { withConfirmSelect = false
-                              prefetchCount = prefetchCount }
-                            connection
-                        |> AsyncResult.map (fun rpcChannel ->
-                            (connection,
-                             Model
-                                 { channelConsumer = AsyncEventingBasicConsumer channel
-
-                                   rpcConsumer = AsyncEventingBasicConsumer rpcChannel
-
-                                   pendingRequests =
-                                       System.Collections.Concurrent.ConcurrentDictionary<string, Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource>
-                                           ()
-                                   connection = connection
-                                   ignoreCallbacksWhileClosing = false }))))
-                |> AsyncResult.bind (fun (connection, model) ->
-                    let declareAQueue = declareQueue model
-                    let bindAQueue = bindQueueToExchange model
-
-                    let consumeAQueue = consumeQueue model (System.Guid.NewGuid().ToString())
-
-                    getTopology model
-                    |> List.fold
-                        (fun prevResult queueTopology ->
-                            AsyncResult.bind
-                                (fun _ ->
-                                    declareAQueue queueTopology
-                                    |> AsyncResult.bind bindAQueue
-                                    |> AsyncResult.bind (consumeAQueue >> Async.map Ok))
-                                prevResult)
-                        (AsyncResult.singleton model)
-                    |> AsyncResult.mapError (fun error ->
-                        closeConnection 3000.0 connection
-                        error)
-                    |> AsyncResult.bind (
-                        initReplyQueue
-                        >> Async.map (fun model ->
-                            Ok(
-                                model,
-                                (fun () ->
-                                    connection.AbortAsync connectionCloseTimeout
-                                    |> Async.AwaitTask
-                                    |> Async.RunSynchronously)
-                            ))
-                    )))
-
-    /// Will publish with confirm.
-    let publishToQueue: Model -> System.TimeSpan -> string -> PublishMessage -> Async<PublishResult> =
-        fun (Model model) timeout routingKey message ->
+    /// The consumed message will be nacked after a specified delay. Will return after waiting for the delay.
+    let private nackWithDelayBlockingAsync (delay: System.TimeSpan) : ReceivedMessage -> Async<unit> =
+        fun message ->
             async {
-                let tcs = System.Threading.Tasks.TaskCompletionSource<PublishResult>()
-
-                use ct = new System.Threading.CancellationTokenSource(timeout)
-
-                use _ctr =
-                    ct.Token.Register(
-                        callback =
-                            (fun () ->
-                                tcs.SetResult(
-                                    $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString()}s"
-                                    |> PublishResult.Timeout
-                                )),
-                        useSynchronizationContext = false
-                    )
-
-                let messageId = System.Guid.NewGuid().ToString()
-
-                let basicReturnEventHandler = createBasicReturnEventHandler messageId tcs
-
-                model.channelConsumer.Channel.add_BasicReturnAsync basicReturnEventHandler
-
-                let! basicAckEventHandler, basicNackEventHandler =
-                    lock model (fun () ->
-                        async {
-                            let! nextPublishSeqNo =
-                                model
-                                    .channelConsumer
-                                    .Channel
-                                    .GetNextPublishSequenceNumberAsync()
-                                    .AsTask()
-                                |> Async.AwaitTask
-
-                            let basicAckEventHandler = createBasicAckEventHandler nextPublishSeqNo tcs
-
-                            model.channelConsumer.Channel.add_BasicAcksAsync basicAckEventHandler
-
-                            let basicNackEventHandler = createBasicNackEventHandler nextPublishSeqNo tcs
-
-                            model.channelConsumer.Channel.add_BasicNacksAsync basicNackEventHandler
-
-                            do!
-                                model
-                                    .channelConsumer
-                                    .Channel
-                                    .BasicPublishAsync(
-                                        exchange = "",
-                                        routingKey = routingKey,
-                                        mandatory = true,
-                                        basicProperties =
-                                            BasicProperties(
-                                                ContentType = contentTypeStringFromContent message.Content,
-                                                Persistent = true,
-                                                MessageId = messageId,
-                                                CorrelationId =
-                                                    (match message.CorrelationId with
-                                                     | CorrelationId.Generate -> ""
-                                                     | CorrelationId.Id correlationId -> correlationId),
-                                                Headers =
-                                                    (message.Headers
-                                                     |> Map.map (fun _ v -> v :> obj)
-                                                     |> (Map.toSeq >> dict))
-                                            ),
-                                        body = bodyFromContent message.Content
-                                    )
-                                    .AsTask()
-                                |> Async.AwaitTask
-
-                            return (basicAckEventHandler, basicNackEventHandler)
-                        })
-
-                let! publishResult = tcs.Task |> (Async.AwaitTask >> Async.Catch)
-
-                model.channelConsumer.Channel.remove_BasicAcksAsync basicAckEventHandler
-
-                model.channelConsumer.Channel.remove_BasicNacksAsync basicNackEventHandler
-
-                model.channelConsumer.Channel.remove_BasicReturnAsync basicReturnEventHandler
-
-                return
-                    match publishResult with
-                    | Choice1Of2 result -> result
-
-                    | Choice2Of2 reason -> PublishResult.Unknown $"Task cancelled: %A{reason}"
+                do! Async.Sleep (int delay.TotalMilliseconds |> max 0 |> min System.Int32.MaxValue)
+                return! nackAsync message
             }
 
-    let replyToMessage: Model -> ReceivedMessage -> Map<string, string> -> Content -> Async<PublishResult> =
-        fun (Model model) receivedMessage headers content ->
-            receivedMessage
-            |> extractReplyProperties
-            |> AsyncResult.fromResult
-            |> Async.bind (function
-                | Ok replyProperties ->
-                    let headers = Map.add "sequence_end" "true" headers // sequence_end is required by Rabbot clients (https://github.com/arobson/rabbot/issues/76)
+    /// The consumed message will be nacked after a specified delay. Will return without waiting for the delay.
+    let nackWithDelayNonBlockingAsync (delay: System.TimeSpan) : ReceivedMessage -> Async<unit> =
+        fun message ->
+            async {
+                // `StartChild` means we share the same `cancellation token`,
+                // so any exceptions should be propagated back to this call.
+                let! _ = nackWithDelayBlockingAsync delay message |> Async.StartChild
+                return ()
+            }
+
+    let messageBody (ReceivedMessage (event, _): ReceivedMessage) : string =
+        System.Text.Encoding.UTF8.GetString event.Body.Span
+
+    let messageRoutingKey (ReceivedMessage (event, _): ReceivedMessage) : string = event.RoutingKey
+
+    let replyAsync
+        (ReceivedMessage (eventArgs, consumer): ReceivedMessage)
+        (replyMessage: ReplyMessage)
+        : Async<Result<unit, string>> =
+        task {
+            try
+                match eventArgs.BasicProperties.ReplyTo, eventArgs.BasicProperties.MessageId with
+                | null, _ -> return Error "Missing reply_to property."
+                | _, null -> return Error "Missing message_id property."
+
+                | replyTo, correlationId ->
+                    let messageId = System.Guid.NewGuid().ToString ()
 
                     let contentType, body =
-                        match content with
-                        | Json jsonContent -> ("application/json", System.Text.Encoding.UTF8.GetBytes jsonContent)
-                        | Binary bytes -> ("application/octet-stream", bytes)
+                        match replyMessage.body with
+                        | Json jsonContent -> "application/json", System.Text.Encoding.UTF8.GetBytes jsonContent
 
-                    let messageId = System.Guid.NewGuid().ToString()
+                    let publishWithHeaders =
+                        // `sequence_end` is required by rabbot (foo-foo-mq) clients (https://github.com/arobson/rabbot/issues/76).
+                        ("sequence_end", "true") :: replyMessage.headers
+                        |> Seq.map (fun (k, v) -> k, v :> obj)
+                        |> dict
 
-                    model
-                        .channelConsumer
-                        .Channel
-                        .BasicPublishAsync(
+                    do!
+                        consumer.Channel.BasicPublishAsync (
                             exchange = "",
-                            routingKey = replyProperties.ReplyTo,
-                            // mandatory must be false when publishing to direct-reply-to queue https://www.rabbitmq.com/direct-reply-to.html#limitations
+                            routingKey = replyTo,
+                            // mandatory should be false when publishing to a direct-reply-to queue (https://www.rabbitmq.com/direct-reply-to.html#limitations)
+                            // which is a very common use case for replies.
                             mandatory = false,
                             basicProperties =
-                                BasicProperties(
+                                BasicProperties (
                                     ContentType = contentType,
                                     Persistent = true,
                                     MessageId = messageId,
-                                    CorrelationId = replyProperties.CorrelationId,
-                                    Headers =
-                                        (headers
-                                         |> Map.map (fun _ v -> v :> obj)
-                                         |> (Map.toSeq >> dict))
+                                    CorrelationId = correlationId,
+                                    Headers = publishWithHeaders
                                 ),
                             body = body
                         )
-                        .AsTask()
-                    |> Async.AwaitTask
-                    |> Async.map (fun _ -> PublishResult.Acked)
 
-                | Error errorMessage -> Async.singleton (PublishResult.Unknown errorMessage))
+                    return Ok ()
 
-    /// <summary>Make an RPC-call to a RabbitMq queue.</summary>
-    /// <param name="Model">MqClient model.</param>#pragma warning disable 3390
-    /// <param name="timeout">Seconds before timing out request.</param>
-    /// <param name="routingKey">Routing key to publish message to.</param>
-    /// <param name="message">Message to be published.</param>
-    /// <returns>Response from called RPC endpoint or error.</returns>
-    let request: Model -> System.TimeSpan -> string -> PublishMessage -> AsyncResult<ReceivedMessage, string> =
-        fun (Model model) timeout routingKey message ->
-            async {
-                let tcs =
-                    System.Threading.Tasks.TaskCompletionSource<Result<ReceivedMessage, string>>()
+            with exn ->
+                return Error (string exn)
+        }
+        |> Async.AwaitTask
 
-                use ct = new System.Threading.CancellationTokenSource(timeout)
+    /// <summary>Declares and optionally binds the specified queue, then starts consuming messages.</summary>
+    /// <param name="queuePrefetchCount">Maximum number of unacked messages to be fetched at once. The messages will still be processed one at a time.</param>
+    /// <param name="queueConfig">Queue configuration.</param>
+    let initAsync
+        (queuePrefetchCount: QueuePrefetchCount)
+        (queueConfig: QueueConfig)
+        (Connection connection: Connection)
+        : Async<Result<Model, string>> =
+        task {
+            try
+                let! channel = connection.CreateChannelAsync ()
 
-                let messageId = System.Guid.NewGuid().ToString()
+                let prefetchCount =
+                    match queuePrefetchCount with
+                    | TenMessages -> 10us
 
-                use _ctr =
-                    ct.Token.Register(
-                        callback =
-                            (fun () ->
-                                dictRemoveMutable messageId model.pendingRequests
-                                |> ignore
+                do! channel.BasicQosAsync (uint32 0, prefetchCount, false)
 
-                                tcs.TrySetResult(
-                                    Error
-                                        $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString()}s"
-                                )
-                                |> ignore),
+                channel.add_CallbackExceptionAsync (fun _ _ ->
+                    task {
+                        do!
+                            connection.AbortAsync (
+                                uint16 Constants.ChannelError,
+                                "RabbitMqClient.Consumer: Unhandled channel exception, closing connection",
+                                connectionCloseTimeout
+                            )
+                    }
+                )
+
+                let! _ =
+                    channel.QueueDeclareAsync (
+                        queue = queueConfig.queueName,
+                        durable = true,
+                        exclusive = false,
+                        autoDelete = false,
+                        arguments =
+                            dict (
+                                ("x-queue-type",
+                                 match queueConfig.queueType with
+                                 | Quorum -> "quorum"
+                                 | Classic -> "classic"
+                                 :> obj)
+                                :: (queueConfig.messageTimeToLive
+                                    |> Option.map (fun ttl -> [ "x-message-ttl", ttl :> obj ])
+                                    |> Option.defaultValue [])
+                            )
+                    )
+
+                if Option.isSome queueConfig.bindToExchange then
+                    do!
+                        channel.QueueBindAsync (
+                            queue = queueConfig.queueName,
+                            exchange = queueConfig.bindToExchange.Value,
+                            routingKey = "*",
+                            arguments = null
+                        )
+
+                let consumer = AsyncEventingBasicConsumer channel
+
+                let consumerTag =
+                    $"%s{queueConfig.queueName}-consumer-%s{System.Guid.NewGuid().ToString ()}"
+
+                consumer.add_ReceivedAsync (fun _ event ->
+                    task {
+                        if event.ConsumerTag = consumerTag then
+                            do! queueConfig.callbacks.onReceived (ReceivedMessage (event, consumer))
+                    }
+                )
+
+                consumer.add_RegisteredAsync (fun _ eventArgs ->
+                    task {
+                        if eventArgs.ConsumerTags |> Array.contains consumerTag then
+                            queueConfig.callbacks.onRegistered queueConfig.queueName
+                    }
+                )
+
+                consumer.add_UnregisteredAsync (fun _ eventArgs ->
+                    task {
+                        if eventArgs.ConsumerTags |> Array.contains consumerTag then
+                            let replyCode, replyText =
+                                if consumer.ShutdownReason = null then
+                                    0, "Missing ShutdownReason. Did the queue got deleted?"
+                                else
+                                    int consumer.ShutdownReason.ReplyCode, consumer.ShutdownReason.ReplyText
+
+                            queueConfig.callbacks.onUnregistered {
+                                queueName = queueConfig.queueName
+                                replyCode = replyCode
+                                replyText = replyText
+                            }
+                    }
+                )
+
+                consumer.add_ShutdownAsync (fun _ eventArgs ->
+                    task {
+                        queueConfig.callbacks.onShutdown {
+                            queueName = queueConfig.queueName
+                            replyCode = int eventArgs.ReplyCode
+                            replyText = eventArgs.ReplyText
+                        }
+                    }
+                )
+
+                let! _ =
+                    channel.BasicConsumeAsync (
+                        queue = queueConfig.queueName,
+                        autoAck = false,
+                        consumerTag = consumerTag,
+                        noLocal = false,
+                        exclusive = false,
+                        arguments = null,
+                        consumer = consumer
+                    )
+
+                return Ok (Consumer consumer)
+
+            with exn ->
+                // Abort connection gracefully on any unexpected error.
+                do! connection.AbortAsync connectionCloseTimeout
+
+                return Error $"RabbitMqClient.Consumer: %s{string exn}"
+        }
+        |> Async.AwaitTask
+
+    /// <summary>Wrap callbacks with default implementations. Will terminate the process on unexpected events.</summary>
+    /// <param name="logger">Logger.</param>
+    /// <param name="onReceivedAsync">Callback that's called when a new message is received.</param>
+    /// <returns>Callbacks</returns>
+    let terminateOnUnexpectedEvents (logger: ILogger) (onReceivedAsync: ReceivedMessage -> Async<unit>) : Callbacks = {
+        onReceived =
+            fun message ->
+                async {
+                    try
+                        do! onReceivedAsync message
+                    with exn ->
+                        logger.LogError (
+                            exn,
+                            "Got unexpected error during event `Received`. Will terminate the process"
+                        )
+
+                        exit 9
+                }
+
+        onRegistered = fun queueName -> logger.LogInformation ("Consumer registered on queue {queueName}", queueName)
+
+        onUnregistered =
+            fun event ->
+                // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                if event.replyCode <> Constants.ReplySuccess then
+                    logger.LogError (
+                        "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                        event.queueName,
+                        event.replyCode,
+                        event.replyText
+                    )
+
+                    exit 11
+
+        onShutdown =
+            fun event ->
+                // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                if event.replyCode = Constants.ReplySuccess then
+                    logger.LogInformation (
+                        "Got expected event `Shutdown` for consumer on queue {queueName}",
+                        event.queueName
+                    )
+
+                else
+                    logger.LogError (
+                        "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                        event.queueName,
+                        event.replyCode,
+                        event.replyText
+                    )
+
+                    exit 13
+    }
+
+module RPC =
+    open System.Threading
+    open System.Collections.Concurrent
+
+    type Client = { requestAsync: RequestAsync }
+
+    and RequestAsync = RequestMessage -> Async<Result<ResponseMessage, string>>
+
+    and RequestMessage = {
+        queue: string
+        headers: List<string * string>
+        body: RequestBody
+        timeout: System.TimeSpan
+    }
+
+    and RequestBody = Json of string
+
+    and ResponseMessage = {
+        body: string
+        headers: System.Collections.Generic.IDictionary<string, obj>
+    }
+
+    type private CorrelationId = string
+
+    type private PendingRequests =
+        ConcurrentDictionary<CorrelationId, TaskCompletionSource<Result<ResponseMessage, string>>>
+
+    [<Literal>]
+    let private queueDirectReplyTo = "amq.rabbitmq.reply-to"
+
+    let private requestAsync (pendingRequests: PendingRequests) (consumer: AsyncEventingBasicConsumer) : RequestAsync =
+        fun message ->
+            task {
+                let messageId = System.Guid.NewGuid().ToString ()
+
+                let completionSource = TaskCompletionSource<_> ()
+
+                use cancellationSource = new CancellationTokenSource (message.timeout)
+
+                let cancellationCallback () =
+                    // Ensure the  pending request is removed to prevent memory leaks.
+                    pendingRequests.TryRemove messageId |> ignore
+
+                    // Try set error result.
+                    completionSource.TrySetResult (
+                        $"Request to queue '%s{message.queue}' timed out after %s{message.timeout.TotalSeconds.ToString ()}s"
+                        |> Error
+                    )
+                    |> ignore
+
+                // On received reply we will return from this function and `Dispose` will be called.
+                // `Dispose` will cancel the call to the callback.
+                use _cancellationRegistration =
+                    cancellationSource.Token.Register (
+                        callback = cancellationCallback,
                         useSynchronizationContext = false
                     )
 
                 try
-                    if model.pendingRequests.TryAdd(messageId, tcs) then
+                    if pendingRequests.TryAdd (messageId, completionSource) then
+                        let contentType, requestBody =
+                            match message.body with
+                            | Json json -> "application/json", System.Text.Encoding.UTF8.GetBytes json
+
+                        let requestHeaders = message.headers |> Seq.map (fun (k, v) -> k, v :> obj) |> dict
+
                         do!
-                            model
-                                .rpcConsumer
-                                .Channel
-                                .BasicPublishAsync(
-                                    exchange = "",
-                                    routingKey = routingKey,
-                                    mandatory = true,
-                                    basicProperties =
-                                        BasicProperties(
-                                            ContentType = contentTypeStringFromContent message.Content,
-                                            Persistent = false,
-                                            MessageId = messageId,
-                                            ReplyTo = "amq.rabbitmq.reply-to",
-                                            Headers =
-                                                (message.Headers
-                                                 |> Map.map (fun _ v -> v :> obj)
-                                                 |> (Map.toSeq >> dict))
-                                        ),
-                                    body = bodyFromContent message.Content
-                                )
-                                .AsTask()
-                            |> Async.AwaitTask
+                            consumer.Channel.BasicPublishAsync (
+                                exchange = "",
+                                routingKey = message.queue,
+                                // We don't care if the reply message got routed or not as we're using timeout.
+                                mandatory = false,
+                                basicProperties =
+                                    BasicProperties (
+                                        ContentType = contentType,
+                                        Persistent = false,
+                                        MessageId = messageId,
+                                        ReplyTo = queueDirectReplyTo,
+                                        Headers = requestHeaders
+                                    ),
+                                body = requestBody
+                            )
 
-                        let! result = tcs.Task |> (Async.AwaitTask >> Async.Catch)
+                        return! completionSource.Task
 
-                        return
-                            match result with
-                            | Choice1Of2 result -> result
-
-                            | Choice2Of2 reason -> Error reason.Message
                     else
-                        return Error $"Duplicate message id: %s{messageId}"
+                        return Error $"RabbitMqClient.RPC.request: Duplicate message id %s{messageId}"
 
-                with
-                | :? System.ArgumentNullException as ex -> return Error ex.Message
-
-                | :? System.OverflowException as ex -> return Error ex.Message
+                with exn ->
+                    return Error (string exn)
             }
+            |> Async.AwaitTask
 
-    /// <summary>Wrap callbacks with default implementation for OnRegistered,
-    /// OnUnregistered, OnConsumerCancelled, OnShutdown. If any message is received
-    /// for OnConsumerCancelled or OnShutdown the system will exit with error code 9</summary>
-    /// <param name="logger">Logger.</param>
-    /// <param name="onReceived">Callback that's called when a new message is received.</param>
-    /// <returns>Callbacks</returns>
-    let terminateOnFailureWrapper: ILogger -> (ReceivedMessage -> Async<unit>) -> Callbacks =
-        fun logger onReceived ->
-            { OnReceived =
-                fun message ->
-                    // Something weird happens with exception handling when not
-                    // using Async computational expression. Some exceptions are
-                    // silently swallowed and never bubbles up.
-                    async {
-                        try
-                            do! onReceived message
-                        with
-                        | exn ->
-                            logger.LogError(exn, $"💥 Unexpected error. %A{exn}\nShutting down", ())
-                            exit 9
+    let initAsync
+        (logger: ILogger)
+        (clientName: string)
+        (Connection connection: Connection)
+        : Async<Result<Client, string>> =
+        task {
+            try
+                let pendingRequests: PendingRequests = ConcurrentDictionary ()
+
+                let consumerTag =
+                    queueDirectReplyTo
+                    + "-"
+                    + clientName
+                    + "-consumer-"
+                    + System.Guid.NewGuid().ToString ()
+
+                let! channel = connection.CreateChannelAsync ()
+
+                channel.add_CallbackExceptionAsync (fun _ eventArgs ->
+                    task {
+                        let reason = $"%s{clientName}: Unhandled channel exception, closing connection"
+
+                        logger.LogError (eventArgs.Exception, reason)
+
+                        do! connection.AbortAsync (uint16 Constants.ChannelError, reason, connectionCloseTimeout)
+                    }
+                )
+
+                let consumer = AsyncEventingBasicConsumer channel
+
+                consumer.add_ReceivedAsync (fun _ eventArgs ->
+                    task {
+                        let correlationId = eventArgs.BasicProperties.CorrelationId
+
+                        match pendingRequests.TryRemove correlationId with
+                        | true, tcs ->
+                            let responseMessage: ResponseMessage = {
+                                body = System.Text.Encoding.UTF8.GetString eventArgs.Body.Span
+                                headers = eventArgs.BasicProperties.Headers
+                            }
+
+                            if not (tcs.TrySetResult (Ok responseMessage)) then
+                                logger.LogWarning (
+                                    "Consumer {clientName} received reply but unable to set task completion source with correlation id {correlationId}",
+                                    clientName,
+                                    correlationId
+                                )
+
+                        | _ ->
+                            logger.LogWarning (
+                                "Consumer {clientName} received reply without known correlation id: {correlationId}",
+                                clientName,
+                                correlationId
+                            )
+                    }
+                )
+
+                consumer.add_RegisteredAsync (fun _ eventArgs ->
+                    task {
+                        logger.LogInformation (
+                            "Consumer {clientName} registered {consumerTags}",
+                            clientName,
+                            eventArgs.ConsumerTags
+                        )
+                    }
+                )
+
+                consumer.add_UnregisteredAsync (fun _ eventArgs ->
+                    task {
+                        let replyCode =
+                            if consumer.ShutdownReason = null then
+                                0
+                            else
+                                int consumer.ShutdownReason.ReplyCode
+
+                        // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                        if replyCode <> Constants.ReplySuccess then
+                            logger.LogWarning (
+                                "Consumer {clientName} unregistered {consumerTags}",
+                                clientName,
+                                eventArgs.ConsumerTags
+                            )
+                    }
+                )
+
+                consumer.add_ShutdownAsync (fun _ eventArgs ->
+                    task {
+                        if eventArgs.ReplyCode = uint16 Constants.ReplySuccess then
+                            logger.LogInformation ("Got expected event `Shutdown` for {clientName}", clientName)
+
+                        else
+                            logger.LogWarning (
+                                "Get unexpected event `Shutdown` for {clientName}. {replyCode} - {replyText}",
+                                clientName,
+                                eventArgs.ReplyCode,
+                                eventArgs.ReplyText
+                            )
+                    }
+                )
+
+                let! _ =
+                    channel.BasicConsumeAsync (
+                        queue = queueDirectReplyTo,
+                        autoAck = true, // Must be true for direct-reply-to.
+                        consumerTag = consumerTag,
+                        noLocal = false,
+                        exclusive = false,
+                        arguments = null,
+                        consumer = consumer
+                    )
+
+                return
+                    Ok {
+                        requestAsync = requestAsync pendingRequests consumer
                     }
 
-              OnRegistered = fun _ -> Async.singleton ()
-
-              OnUnregistered =
-
-                  fun event ->
-                      // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
-                      if event.replyCode <> Constants.ReplySuccess then
-                          logger.LogError(
-                              "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
-                              event.queueName,
-                              event.replyCode,
-                              event.replyText
-                          )
-
-                          exit 11
-
-              OnConsumerCancelled =
-                  fun _ ->
-                      logger.LogError("Got OnConsumerCancelled event", ())
-                      exit 11
-
-              OnShutdown =
-                  fun event ->
-                      // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
-                      if event.replyCode <> Constants.ReplySuccess then
-                          logger.LogError(
-                              "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
-                              event.queueName,
-                              event.replyCode,
-                              event.replyText
-                          )
-
-                          exit 13
-
-            }
+            with exn ->
+                return Error (string exn)
+        }
+        |> Async.AwaitTask

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -104,8 +104,6 @@ module MqClient =
     type ConnectionConfig = {
         connectionName: string
         endpoints: List<AmqpTcpEndpoint>
-        username: string
-        password: string
         onConnectionShutdown: OnConnectionShutdown
     }
 
@@ -249,10 +247,7 @@ module MqClient =
                         AutomaticRecoveryEnabled = false,
 
                         RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
-                        VirtualHost = "quorum-vhost",
-
-                        UserName = connectionConfig.username,
-                        Password = connectionConfig.password
+                        VirtualHost = "quorum-vhost"
                     )
 
                 let! connection =

--- a/src/Insurello.RabbitMqClient/MqClient.fs
+++ b/src/Insurello.RabbitMqClient/MqClient.fs
@@ -13,17 +13,12 @@ module MqClient =
 
     type private ExceptionCallback = System.Exception -> string -> IConnection -> unit
 
-    type private ModelData = {
-        channelConsumer: AsyncEventingBasicConsumer
-        rpcConsumer: AsyncEventingBasicConsumer
-        pendingRequests:
-            System.Collections.Concurrent.ConcurrentDictionary<
-                string,
-                Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource
-             >
-        connection: IConnection
-        mutable ignoreCallbacksWhileClosing: bool
-    }
+    type private ModelData =
+        { channelConsumer: AsyncEventingBasicConsumer
+          rpcConsumer: AsyncEventingBasicConsumer
+          pendingRequests: System.Collections.Concurrent.ConcurrentDictionary<string, Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource>
+          connection: IConnection
+          mutable ignoreCallbacksWhileClosing: bool }
 
     and Message<'event> = private Message of 'event * ModelData
 
@@ -49,23 +44,26 @@ module MqClient =
         | DefaultToTen
         | Count of int
 
-    type Callbacks = {
-        OnReceived: ReceivedMessage -> Async<unit>
-        OnRegistered: ConsumerEventArgs Message -> Async<unit>
-        OnUnregistered: ConsumerEventArgs Message -> Async<unit>
-        OnConsumerCancelled: ConsumerEventArgs Message -> Async<unit>
-        OnShutdown: ShutdownEventArgs Message -> Async<unit>
-    }
+    type Callbacks =
+        { OnReceived: ReceivedMessage -> Async<unit>
+          OnRegistered: ConsumerEventArgs Message -> Async<unit>
+          OnUnregistered: UnregisteredEvent -> unit
+          OnConsumerCancelled: ConsumerEventArgs Message -> Async<unit>
+          OnShutdown: UnregisteredEvent -> unit }
+
+    and UnregisteredEvent =
+        { queueName: string
+          replyCode: int
+          replyText: string }
 
     type Topology = QueueTopology list
 
-    and QueueTopology = {
-        Queue: string
-        BindToExchange: string option
-        ConsumeCallbacks: Callbacks
-        MessageTimeToLive: int option
-        QueueType: QueueType
-    }
+    and QueueTopology =
+        { Queue: string
+          BindToExchange: string option
+          ConsumeCallbacks: Callbacks
+          MessageTimeToLive: int option
+          QueueType: QueueType }
 
     and QueueType =
         | Classic
@@ -90,30 +88,26 @@ module MqClient =
         | Generate
         | Id of string
 
-    type PublishMessage = {
-        CorrelationId: CorrelationId
-        Headers: Map<string, string>
-        Content: Content
-    }
+    type PublishMessage =
+        { CorrelationId: CorrelationId
+          Headers: Map<string, string>
+          Content: Content }
 
-    type private ChannelConfig = {
-        withConfirmSelect: bool
-        prefetchCount: uint16
-    }
+    type private ChannelConfig =
+        { withConfirmSelect: bool
+          prefetchCount: uint16 }
 
-    type ConnectionConfig = {
-        connectionName: string
-        endpoints: List<AmqpTcpEndpoint>
-        onConnectionShutdown: OnConnectionShutdown
-    }
+    type ConnectionConfig =
+        { connectionName: string
+          endpoints: List<AmqpTcpEndpoint>
+          onConnectionShutdown: OnConnectionShutdown }
 
     and OnConnectionShutdown = OnConnectionShutdownEvent -> unit
 
-    and OnConnectionShutdownEvent = {
-        connectionName: string
-        replyCode: int
-        replyText: string
-    }
+    and OnConnectionShutdownEvent =
+        { connectionName: string
+          replyCode: int
+          replyText: string }
 
     type CloseConnection = unit -> unit
 
@@ -124,7 +118,7 @@ module MqClient =
         | Json _ -> "application/json"
         | Binary _ -> "application/octet-stream"
 
-    let private bodyFromContent: Content -> byte[] =
+    let private bodyFromContent: Content -> byte [] =
         function
         | Json jsonContent -> System.Text.Encoding.UTF8.GetBytes jsonContent
         | Binary binaryContent -> binaryContent
@@ -141,32 +135,26 @@ module MqClient =
             | null -> Error "Missing message_id property."
             | messageId -> Ok messageId
 
-    let extractReplyProperties
-        : Message<BasicDeliverEventArgs>
-              -> Result<
-                  {|
-                      ReplyTo: string
-                      CorrelationId: string
-                  |},
-                  string
-               > =
+    let extractReplyProperties: Message<BasicDeliverEventArgs>
+        -> Result<{| ReplyTo: string
+                     CorrelationId: string |}, string> =
         fun (Message (event, _)) ->
             event
             |> extractReplyTo
             |> Result.bind (fun replyTo ->
                 extractMesssageId event
-                |> Result.map (fun messageId -> {|
-                    ReplyTo = replyTo
-                    CorrelationId = messageId
-                |})
-            )
+                |> Result.map (fun messageId ->
+                    {| ReplyTo = replyTo
+                       CorrelationId = messageId |}))
 
     let routingKeyFromMessage: ReceivedMessage -> string =
         fun (Message (event, _)) -> event.RoutingKey
 
     let private asTask: ModelData -> 'event -> (Message<'event> -> Async<unit>) -> System.Threading.Tasks.Task =
         fun model event callback ->
-            async { do! callback (Message (event, model)) } |> Async.StartAsTask :> System.Threading.Tasks.Task
+            async { do! callback (Message(event, model)) }
+            |> Async.StartAsTask
+            :> System.Threading.Tasks.Task
 
     let private consumeQueue: Model -> string -> QueueTopology -> Async<Model> =
         fun (Model model) uniqueTag queueTopology ->
@@ -174,37 +162,49 @@ module MqClient =
             let consumerTag = queueTopology.Queue + "-consumer-" + uniqueTag
 
             let doNothingTask: unit -> System.Threading.Tasks.Task =
-                (fun () -> async.Return () |> Async.StartAsTask :> System.Threading.Tasks.Task)
+                (fun () -> async.Return() |> Async.StartAsTask :> System.Threading.Tasks.Task)
 
             model.channelConsumer.add_ReceivedAsync (fun _sender event ->
                 if event.ConsumerTag = consumerTag then
                     asTask model event queueTopology.ConsumeCallbacks.OnReceived
                 else
-                    doNothingTask ()
-            )
+                    doNothingTask ())
 
             model.channelConsumer.add_RegisteredAsync (fun _sender event ->
                 if event.ConsumerTags.Contains consumerTag then
                     asTask model event queueTopology.ConsumeCallbacks.OnRegistered
                 else
-                    doNothingTask ()
-            )
+                    doNothingTask ())
 
-            model.channelConsumer.add_UnregisteredAsync (fun _sender event ->
-                if event.ConsumerTags.Contains consumerTag then
-                    asTask model event queueTopology.ConsumeCallbacks.OnUnregistered
-                else
-                    doNothingTask ()
+            model.channelConsumer.add_UnregisteredAsync (fun _sender eventArgs ->
+                task {
+                    let shutdownReason = model.channelConsumer.ShutdownReason
+
+                    if eventArgs.ConsumerTags
+                       |> Array.contains consumerTag then
+                        let replyCode, replyText =
+                            if shutdownReason = null then
+                                0, "Missing ShutdownReason. Did the queue got deleted?"
+                            else
+                                int shutdownReason.ReplyCode, shutdownReason.ReplyText
+
+                        queueTopology.ConsumeCallbacks.OnUnregistered
+                            { queueName = queueTopology.Queue
+                              replyCode = replyCode
+                              replyText = replyText }
+                }
+
             )
 
             model.channelConsumer.add_ShutdownAsync (fun _sender event ->
-                if not model.ignoreCallbacksWhileClosing then
-                    asTask model event queueTopology.ConsumeCallbacks.OnShutdown
-                else
-                    doNothingTask ()
-            )
+                task {
+                    queueTopology.ConsumeCallbacks.OnShutdown
+                        { queueName = queueTopology.Queue
+                          replyCode = int model.channelConsumer.ShutdownReason.ReplyCode
+                          replyText = model.channelConsumer.ShutdownReason.ReplyText }
+                })
 
-            model.channelConsumer.Channel.BasicConsumeAsync (
+            model.channelConsumer.Channel.BasicConsumeAsync(
                 queue = queueTopology.Queue,
                 autoAck = false,
                 consumerTag = consumerTag,
@@ -227,10 +227,10 @@ module MqClient =
         fun event ->
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
-                logger.LogWarning ("Closing RabbitMQ connection {connectionName}", event.connectionName)
+                logger.LogWarning("Closing RabbitMQ connection {connectionName}", event.connectionName)
 
             else if event.replyCode <> Constants.ReplySuccess then
-                logger.LogError (
+                logger.LogError(
                     "Got unexpected event `Shutdown` on connection {connectionName}. {replyCode} - {replyText}. Will terminate the process",
                     event.connectionName,
                     event.replyCode,
@@ -243,7 +243,7 @@ module MqClient =
         task {
             try
                 let factory =
-                    ConnectionFactory (
+                    ConnectionFactory(
                         AutomaticRecoveryEnabled = false,
 
                         RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
@@ -251,32 +251,32 @@ module MqClient =
                     )
 
                 let! connection =
-                    factory.CreateConnectionAsync (
+                    factory.CreateConnectionAsync(
                         endpoints = connectionConfig.endpoints,
                         clientProvidedName = connectionConfig.connectionName
                     )
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
-                        connectionConfig.onConnectionShutdown {
-                            connectionName = connectionConfig.connectionName
-                            replyCode = int eventArgs.ReplyCode
-                            replyText = eventArgs.ReplyText
-                        }
-                    }
-                )
+                        printfn $"Got ConnectionShutdownAsync event with eventArgs: {eventArgs.ReplyCode}"
+
+                        connectionConfig.onConnectionShutdown
+                            { connectionName = connectionConfig.connectionName
+                              replyCode = int eventArgs.ReplyCode
+                              replyText = eventArgs.ReplyText }
+                    })
 
                 return Ok connection
 
-            with exn ->
-                return Error $"%s{connectionConfig.connectionName}: Failed to connect to RabbitMQ: %s{string exn}"
+            with
+            | exn -> return Error $"%s{connectionConfig.connectionName}: Failed to connect to RabbitMQ: %s{string exn}"
         }
         |> Async.AwaitTask
 
     let private closeConnection: float -> IConnection -> unit =
         fun timeout connection ->
             if connection.IsOpen then
-                connection.CloseAsync (System.TimeSpan.FromMilliseconds timeout)
+                connection.CloseAsync(System.TimeSpan.FromMilliseconds timeout)
                 |> Async.AwaitTask
                 |> Async.RunSynchronously
             else
@@ -285,7 +285,7 @@ module MqClient =
     let private closeRpcConsumer: Model -> unit =
         fun (Model model) ->
             if model.rpcConsumer.Channel.IsOpen then
-                model.rpcConsumer.Channel.CloseAsync ()
+                model.rpcConsumer.Channel.CloseAsync()
                 |> Async.AwaitTask
                 |> Async.RunSynchronously
             else
@@ -294,7 +294,7 @@ module MqClient =
     let private closeChannelConsumer: Model -> unit =
         fun (Model model) ->
             if model.channelConsumer.Channel.IsOpen then
-                model.channelConsumer.Channel.CloseAsync ()
+                model.channelConsumer.Channel.CloseAsync()
                 |> Async.AwaitTask
                 |> Async.RunSynchronously
             else
@@ -319,29 +319,28 @@ module MqClient =
             task {
                 try
                     let! channel =
-                        connection.CreateChannelAsync (
-                            CreateChannelOptions (
+                        connection.CreateChannelAsync(
+                            CreateChannelOptions(
                                 publisherConfirmationsEnabled = config.withConfirmSelect,
                                 publisherConfirmationTrackingEnabled = false
                             )
                         )
 
-                    do! channel.BasicQosAsync (uint32 0, config.prefetchCount, false)
+                    do! channel.BasicQosAsync(uint32 0, config.prefetchCount, false)
 
                     channel.add_CallbackExceptionAsync (fun a b ->
                         task {
                             do!
-                                connection.AbortAsync (
+                                connection.AbortAsync(
                                     uint16 Constants.ChannelError,
                                     "RabbitMqClient.Consumer: Unhandled channel exception, closing connection",
                                     connectionCloseTimeout
                                 )
-                        }
-                    )
+                        })
 
                     return Ok channel
-                with :? AlreadyClosedException as ex ->
-                    return Error ex.Message
+                with
+                | :? AlreadyClosedException as ex -> return Error ex.Message
             }
             |> Async.AwaitTask
 
@@ -351,20 +350,18 @@ module MqClient =
 
             let arguments =
                 dict (
-                    [
-                        "x-queue-type",
-                        (match queueTopology.QueueType with
-                         | Quorum -> "quorum"
-                         | Classic -> "classic")
-                        :> obj
-                    ]
+                    [ "x-queue-type",
+                      (match queueTopology.QueueType with
+                       | Quorum -> "quorum"
+                       | Classic -> "classic")
+                      :> obj ]
                     @ (queueTopology.MessageTimeToLive
                        |> Option.map (fun ttl -> [ ("x-message-ttl", ttl :> obj) ])
                        |> Option.defaultValue [])
                 )
 
             try
-                model.channelConsumer.Channel.QueueDeclareAsync (
+                model.channelConsumer.Channel.QueueDeclareAsync(
                     queue = name,
                     durable = true,
                     exclusive = false,
@@ -373,15 +370,15 @@ module MqClient =
                 )
                 |> Async.AwaitTask
                 |> Async.map (fun _ -> Ok queueTopology)
-            with :? OperationInterruptedException as ex ->
-                Async.singleton (Error ex.Message)
+            with
+            | :? OperationInterruptedException as ex -> Async.singleton (Error ex.Message)
 
     let private bindQueueToExchange: Model -> QueueTopology -> AsyncResult<QueueTopology, string> =
         fun (Model model) queueTopology ->
             try
                 match queueTopology.BindToExchange with
                 | Some exchangeName ->
-                    model.channelConsumer.Channel.QueueBindAsync (
+                    model.channelConsumer.Channel.QueueBindAsync(
                         queue = queueTopology.Queue,
                         exchange = nonNullString exchangeName,
                         routingKey = "*",
@@ -391,11 +388,12 @@ module MqClient =
                     |> Async.map (fun () -> Ok queueTopology)
 
                 | None -> Async.singleton (Ok queueTopology)
-            with ex ->
-                Async.singleton (Error ex.Message)
+            with
+            | ex -> Async.singleton (Error ex.Message)
 
-    let private dictRemoveMutable
-        : 'key -> System.Collections.Concurrent.ConcurrentDictionary<'key, 'value> -> 'value option =
+    let private dictRemoveMutable: 'key
+        -> System.Collections.Concurrent.ConcurrentDictionary<'key, 'value>
+        -> 'value option =
         fun key dict ->
             match dict.TryRemove key with
             | true, value -> Some value
@@ -405,45 +403,37 @@ module MqClient =
         fun (Model model) ->
             let queueName = "amq.rabbitmq.reply-to"
 
-            let consumerTag = queueName + "-consumer-" + System.Guid.NewGuid().ToString ()
+            let consumerTag =
+                queueName
+                + "-consumer-"
+                + System.Guid.NewGuid().ToString()
 
             let onReceived: ReceivedMessage -> Async<unit> =
                 (fun (Message (event, _) as message) ->
                     let correlationId = event.BasicProperties.CorrelationId
 
                     match dictRemoveMutable correlationId model.pendingRequests with
-                    | Some tcs -> tcs.TrySetResult (Ok message) |> ignore
+                    | Some tcs -> tcs.TrySetResult(Ok message) |> ignore
 
                     | None -> ()
 
-                    async.Return ()
-                )
+                    async.Return())
 
             model.rpcConsumer.add_ReceivedAsync (fun _sender event -> asTask model event onReceived)
 
-            model.rpcConsumer.add_RegisteredAsync (fun _sender event -> asTask model event (fun _ -> async.Return ()))
+            model.rpcConsumer.add_RegisteredAsync (fun _sender event -> asTask model event (fun _ -> async.Return()))
 
             model.rpcConsumer.add_UnregisteredAsync (fun _sender event ->
-                asTask
-                    model
-                    event
-                    (fun _ ->
-                        failwith "Got Unregistered event on rpc channel"
-                        async.Return ()
-                    )
-            )
+                asTask model event (fun _ ->
+                    failwith "Got Unregistered event on rpc channel"
+                    async.Return()))
 
             model.rpcConsumer.add_ShutdownAsync (fun _sender event ->
-                asTask
-                    model
-                    event
-                    (fun _ ->
-                        if model.ignoreCallbacksWhileClosing then
-                            async.Return ()
-                        else
-                            failwith "Got Shutdown event on rpc channel"
-                    )
-            )
+                asTask model event (fun _ ->
+                    if model.ignoreCallbacksWhileClosing then
+                        async.Return()
+                    else
+                        failwith "Got Shutdown event on rpc channel"))
 
             // TODO: This doesn't exist
             // model.rpcConsumer.add_ConsumerCancelled (fun _sender event ->
@@ -458,7 +448,7 @@ module MqClient =
             //         )
             // )
 
-            model.rpcConsumer.Channel.BasicConsumeAsync (
+            model.rpcConsumer.Channel.BasicConsumeAsync(
                 queue = queueName,
                 autoAck = true, // Must be true for direct-reply-to
                 consumerTag = consumerTag,
@@ -470,23 +460,21 @@ module MqClient =
             |> Async.AwaitTask
             |> Async.map (fun _ -> Model model)
 
-    let private createBasicReturnEventHandler
-        : string
-              -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
-              -> AsyncEventHandler<BasicReturnEventArgs> =
+    let private createBasicReturnEventHandler: string
+        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
+        -> AsyncEventHandler<BasicReturnEventArgs> =
         fun messageId tcs ->
             AsyncEventHandler<BasicReturnEventArgs> (fun _ args ->
                 task {
                     if args.BasicProperties.MessageId = messageId then
-                        tcs.TrySetResult (
+                        tcs.TrySetResult(
                             PublishResult.ReturnError
                                 $"Failed to publish to queue: ReplyCode: %i{args.ReplyCode}, ReplyText: %s{args.ReplyText}, Exchange: %s{args.Exchange}, RoutingKey: %s{args.RoutingKey}"
                         )
                         |> ignore
                     else
                         ()
-                }
-            )
+                })
 
     /// <summary>Returns true if the publishSeqNo is confirmed.</summary>
     /// <param name="publishSeqNo"></param>
@@ -494,10 +482,12 @@ module MqClient =
     /// <param name="multipleConfirms">If false, only one message is confirmed, if true, all messages with a lower or equal sequence number are confirmed.</param>
     let private isConfirmed (publishSeqNo: uint64) (deliveredPublishSeqNo: uint64) (multipleConfirms: bool) : bool =
         publishSeqNo = deliveredPublishSeqNo
-        || multipleConfirms && publishSeqNo < deliveredPublishSeqNo
+        || multipleConfirms
+           && publishSeqNo < deliveredPublishSeqNo
 
-    let private createBasicAckEventHandler
-        : uint64 -> System.Threading.Tasks.TaskCompletionSource<PublishResult> -> AsyncEventHandler<BasicAckEventArgs> =
+    let private createBasicAckEventHandler: uint64
+        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
+        -> AsyncEventHandler<BasicAckEventArgs> =
         fun publishSeqNo tcs ->
             AsyncEventHandler<BasicAckEventArgs> (fun _ args ->
                 task {
@@ -505,11 +495,11 @@ module MqClient =
                         tcs.TrySetResult PublishResult.Acked |> ignore
                     else
                         ()
-                }
-            )
+                })
 
-    let private createBasicNackEventHandler
-        : uint64 -> System.Threading.Tasks.TaskCompletionSource<PublishResult> -> AsyncEventHandler<BasicNackEventArgs> =
+    let private createBasicNackEventHandler: uint64
+        -> System.Threading.Tasks.TaskCompletionSource<PublishResult>
+        -> AsyncEventHandler<BasicNackEventArgs> =
         fun publishSeqNo tcs ->
             AsyncEventHandler<BasicNackEventArgs> (fun _ args ->
                 task {
@@ -517,30 +507,35 @@ module MqClient =
                         tcs.TrySetResult PublishResult.Nacked |> ignore
                     else
                         ()
-                }
-            )
+                })
 
     let ackMessage: ReceivedMessage -> unit =
         fun (Message (event, model)) ->
-            model.channelConsumer.Channel
+            model
+                .channelConsumer
+                .Channel
                 .BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false)
-                .AsTask ()
+                .AsTask()
             |> Async.AwaitTask
             |> Async.RunSynchronously
 
     let nackMessage: ReceivedMessage -> unit =
         fun (Message (event, model)) ->
-            model.channelConsumer.Channel
+            model
+                .channelConsumer
+                .Channel
                 .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
-                .AsTask ()
+                .AsTask()
             |> Async.AwaitTask
             |> Async.RunSynchronously
 
     let nackMessageWithoutRequeue: ReceivedMessage -> unit =
         fun (Message (event, model)) ->
-            model.channelConsumer.Channel
+            model
+                .channelConsumer
+                .Channel
                 .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = false)
-                .AsTask ()
+                .AsTask()
             |> Async.AwaitTask
             |> Async.RunSynchronously
 
@@ -566,8 +561,8 @@ module MqClient =
             |> Async.Sleep
             |> Async.bind (fun () -> nackMessageAsync msg)
 
-    let messageBody: ReceivedMessage -> byte[] =
-        fun (Message (event, _)) -> event.Body.ToArray ()
+    let messageBody: ReceivedMessage -> byte [] =
+        fun (Message (event, _)) -> event.Body.ToArray()
 
     let messageBodyAsString: ReceivedMessage -> RawBody =
         messageBody >> System.Text.Encoding.UTF8.GetString
@@ -587,8 +582,9 @@ module MqClient =
                         match object with
                         | :? array<byte> as byteArray ->
                             try
-                                GetHeaderResult.StringValue (System.Text.Encoding.UTF8.GetString byteArray)
-                            with ex ->
+                                GetHeaderResult.StringValue(System.Text.Encoding.UTF8.GetString byteArray)
+                            with
+                            | ex ->
                                 GetHeaderResult.ErrorConvertingHeaderValueToString
                                     $"Couldn't convert to string. Reason: %s{ex.Message}"
                         | _ -> GetHeaderResult.ErrorConvertingHeaderValueToString "Not a byte array"
@@ -600,10 +596,10 @@ module MqClient =
     let private uint16FromPrefetchConfig: PrefetchConfig -> Result<uint16, string> =
         fun prefetchCount ->
             match prefetchCount with
-            | PrefetchConfig.DefaultToTen -> Ok (uint16 10)
+            | PrefetchConfig.DefaultToTen -> Ok(uint16 10)
             | PrefetchConfig.Count count ->
                 if count >= 0 then
-                    Ok (uint16 count)
+                    Ok(uint16 count)
                 else
                     Error "PrefetchCount value must be a non-negative number"
 
@@ -617,41 +613,31 @@ module MqClient =
                 connect connectionConfig
                 |> AsyncResult.bind (fun connection ->
                     createChannel
-                        {
-                            withConfirmSelect = true
-                            prefetchCount = prefetchCount
-                        }
+                        { withConfirmSelect = true
+                          prefetchCount = prefetchCount }
                         connection
                     |> AsyncResult.bind (fun channel ->
                         createChannel
-                            {
-                                withConfirmSelect = false
-                                prefetchCount = prefetchCount
-                            }
+                            { withConfirmSelect = false
+                              prefetchCount = prefetchCount }
                             connection
                         |> AsyncResult.map (fun rpcChannel ->
                             (connection,
-                             Model {
-                                 channelConsumer = AsyncEventingBasicConsumer channel
+                             Model
+                                 { channelConsumer = AsyncEventingBasicConsumer channel
 
-                                 rpcConsumer = AsyncEventingBasicConsumer rpcChannel
+                                   rpcConsumer = AsyncEventingBasicConsumer rpcChannel
 
-                                 pendingRequests =
-                                     System.Collections.Concurrent.ConcurrentDictionary<
-                                         string,
-                                         Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource
-                                      > ()
-                                 connection = connection
-                                 ignoreCallbacksWhileClosing = false
-                             })
-                        )
-                    )
-                )
+                                   pendingRequests =
+                                       System.Collections.Concurrent.ConcurrentDictionary<string, Result<ReceivedMessage, string> System.Threading.Tasks.TaskCompletionSource>
+                                           ()
+                                   connection = connection
+                                   ignoreCallbacksWhileClosing = false }))))
                 |> AsyncResult.bind (fun (connection, model) ->
                     let declareAQueue = declareQueue model
                     let bindAQueue = bindQueueToExchange model
 
-                    let consumeAQueue = consumeQueue model (System.Guid.NewGuid().ToString ())
+                    let consumeAQueue = consumeQueue model (System.Guid.NewGuid().ToString())
 
                     getTopology model
                     |> List.fold
@@ -660,102 +646,103 @@ module MqClient =
                                 (fun _ ->
                                     declareAQueue queueTopology
                                     |> AsyncResult.bind bindAQueue
-                                    |> AsyncResult.bind (consumeAQueue >> Async.map Ok)
-                                )
-                                prevResult
-                        )
+                                    |> AsyncResult.bind (consumeAQueue >> Async.map Ok))
+                                prevResult)
                         (AsyncResult.singleton model)
                     |> AsyncResult.mapError (fun error ->
                         closeConnection 3000.0 connection
-                        error
-                    )
+                        error)
                     |> AsyncResult.bind (
                         initReplyQueue
                         >> Async.map (fun model ->
-                            Ok (
+                            Ok(
                                 model,
                                 (fun () ->
+                                    printfn "Calling -> connection.AbortAsync connectionCloseTimeout"
+
                                     connection.AbortAsync connectionCloseTimeout
                                     |> Async.AwaitTask
                                     |> Async.RunSynchronously
-                                )
-                            )
-                        )
-                    )
-                )
-            )
+
+                                    printfn "Done -> connection.AbortAsync connectionCloseTimeout"
+
+                                    )
+                            ))
+                    )))
 
     /// Will publish with confirm.
     let publishToQueue: Model -> System.TimeSpan -> string -> PublishMessage -> Async<PublishResult> =
         fun (Model model) timeout routingKey message ->
             async {
-                let tcs = System.Threading.Tasks.TaskCompletionSource<PublishResult> ()
+                let tcs = System.Threading.Tasks.TaskCompletionSource<PublishResult>()
 
-                use ct = new System.Threading.CancellationTokenSource (timeout)
+                use ct = new System.Threading.CancellationTokenSource(timeout)
 
                 use _ctr =
-                    ct.Token.Register (
+                    ct.Token.Register(
                         callback =
                             (fun () ->
-                                tcs.SetResult (
-                                    $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString ()}s"
+                                tcs.SetResult(
+                                    $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString()}s"
                                     |> PublishResult.Timeout
-                                )
-                            ),
+                                )),
                         useSynchronizationContext = false
                     )
 
-                let messageId = System.Guid.NewGuid().ToString ()
+                let messageId = System.Guid.NewGuid().ToString()
 
                 let basicReturnEventHandler = createBasicReturnEventHandler messageId tcs
 
                 model.channelConsumer.Channel.add_BasicReturnAsync basicReturnEventHandler
 
                 let! basicAckEventHandler, basicNackEventHandler =
-                    lock
-                        model
-                        (fun () ->
-                            async {
-                                let! nextPublishSeqNo =
-                                    model.channelConsumer.Channel.GetNextPublishSequenceNumberAsync().AsTask ()
-                                    |> Async.AwaitTask
+                    lock model (fun () ->
+                        async {
+                            let! nextPublishSeqNo =
+                                model
+                                    .channelConsumer
+                                    .Channel
+                                    .GetNextPublishSequenceNumberAsync()
+                                    .AsTask()
+                                |> Async.AwaitTask
 
-                                let basicAckEventHandler = createBasicAckEventHandler nextPublishSeqNo tcs
+                            let basicAckEventHandler = createBasicAckEventHandler nextPublishSeqNo tcs
 
-                                model.channelConsumer.Channel.add_BasicAcksAsync basicAckEventHandler
+                            model.channelConsumer.Channel.add_BasicAcksAsync basicAckEventHandler
 
-                                let basicNackEventHandler = createBasicNackEventHandler nextPublishSeqNo tcs
+                            let basicNackEventHandler = createBasicNackEventHandler nextPublishSeqNo tcs
 
-                                model.channelConsumer.Channel.add_BasicNacksAsync basicNackEventHandler
+                            model.channelConsumer.Channel.add_BasicNacksAsync basicNackEventHandler
 
-                                do!
-                                    model.channelConsumer.Channel
-                                        .BasicPublishAsync(
-                                            exchange = "",
-                                            routingKey = routingKey,
-                                            mandatory = true,
-                                            basicProperties =
-                                                BasicProperties (
-                                                    ContentType = contentTypeStringFromContent message.Content,
-                                                    Persistent = true,
-                                                    MessageId = messageId,
-                                                    CorrelationId =
-                                                        (match message.CorrelationId with
-                                                         | CorrelationId.Generate -> ""
-                                                         | CorrelationId.Id correlationId -> correlationId),
-                                                    Headers =
-                                                        (message.Headers
-                                                         |> Map.map (fun _ v -> v :> obj)
-                                                         |> (Map.toSeq >> dict))
-                                                ),
-                                            body = bodyFromContent message.Content
-                                        )
-                                        .AsTask ()
-                                    |> Async.AwaitTask
+                            do!
+                                model
+                                    .channelConsumer
+                                    .Channel
+                                    .BasicPublishAsync(
+                                        exchange = "",
+                                        routingKey = routingKey,
+                                        mandatory = true,
+                                        basicProperties =
+                                            BasicProperties(
+                                                ContentType = contentTypeStringFromContent message.Content,
+                                                Persistent = true,
+                                                MessageId = messageId,
+                                                CorrelationId =
+                                                    (match message.CorrelationId with
+                                                     | CorrelationId.Generate -> ""
+                                                     | CorrelationId.Id correlationId -> correlationId),
+                                                Headers =
+                                                    (message.Headers
+                                                     |> Map.map (fun _ v -> v :> obj)
+                                                     |> (Map.toSeq >> dict))
+                                            ),
+                                        body = bodyFromContent message.Content
+                                    )
+                                    .AsTask()
+                                |> Async.AwaitTask
 
-                                return (basicAckEventHandler, basicNackEventHandler)
-                            }
-                        )
+                            return (basicAckEventHandler, basicNackEventHandler)
+                        })
 
                 let! publishResult = tcs.Task |> (Async.AwaitTask >> Async.Catch)
 
@@ -777,8 +764,7 @@ module MqClient =
             receivedMessage
             |> extractReplyProperties
             |> AsyncResult.fromResult
-            |> Async.bind (
-                function
+            |> Async.bind (function
                 | Ok replyProperties ->
                     let headers = Map.add "sequence_end" "true" headers // sequence_end is required by Rabbot clients (https://github.com/arobson/rabbot/issues/76)
 
@@ -787,30 +773,34 @@ module MqClient =
                         | Json jsonContent -> ("application/json", System.Text.Encoding.UTF8.GetBytes jsonContent)
                         | Binary bytes -> ("application/octet-stream", bytes)
 
-                    let messageId = System.Guid.NewGuid().ToString ()
+                    let messageId = System.Guid.NewGuid().ToString()
 
-                    model.channelConsumer.Channel
+                    model
+                        .channelConsumer
+                        .Channel
                         .BasicPublishAsync(
                             exchange = "",
                             routingKey = replyProperties.ReplyTo,
                             // mandatory must be false when publishing to direct-reply-to queue https://www.rabbitmq.com/direct-reply-to.html#limitations
                             mandatory = false,
                             basicProperties =
-                                BasicProperties (
+                                BasicProperties(
                                     ContentType = contentType,
                                     Persistent = true,
                                     MessageId = messageId,
                                     CorrelationId = replyProperties.CorrelationId,
-                                    Headers = (headers |> Map.map (fun _ v -> v :> obj) |> (Map.toSeq >> dict))
+                                    Headers =
+                                        (headers
+                                         |> Map.map (fun _ v -> v :> obj)
+                                         |> (Map.toSeq >> dict))
                                 ),
                             body = body
                         )
-                        .AsTask ()
+                        .AsTask()
                     |> Async.AwaitTask
                     |> Async.map (fun _ -> PublishResult.Acked)
 
-                | Error errorMessage -> Async.singleton (PublishResult.Unknown errorMessage)
-            )
+                | Error errorMessage -> Async.singleton (PublishResult.Unknown errorMessage))
 
     /// <summary>Make an RPC-call to a RabbitMq queue.</summary>
     /// <param name="Model">MqClient model.</param>#pragma warning disable 3390
@@ -822,47 +812,51 @@ module MqClient =
         fun (Model model) timeout routingKey message ->
             async {
                 let tcs =
-                    System.Threading.Tasks.TaskCompletionSource<Result<ReceivedMessage, string>> ()
+                    System.Threading.Tasks.TaskCompletionSource<Result<ReceivedMessage, string>>()
 
-                use ct = new System.Threading.CancellationTokenSource (timeout)
+                use ct = new System.Threading.CancellationTokenSource(timeout)
 
-                let messageId = System.Guid.NewGuid().ToString ()
+                let messageId = System.Guid.NewGuid().ToString()
 
                 use _ctr =
-                    ct.Token.Register (
+                    ct.Token.Register(
                         callback =
                             (fun () ->
-                                dictRemoveMutable messageId model.pendingRequests |> ignore
-
-                                tcs.TrySetResult (
-                                    Error
-                                        $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString ()}s"
-                                )
+                                dictRemoveMutable messageId model.pendingRequests
                                 |> ignore
-                            ),
+
+                                tcs.TrySetResult(
+                                    Error
+                                        $"Publish to queue '%s{routingKey}' timedout after %s{timeout.TotalSeconds.ToString()}s"
+                                )
+                                |> ignore),
                         useSynchronizationContext = false
                     )
 
                 try
-                    if model.pendingRequests.TryAdd (messageId, tcs) then
+                    if model.pendingRequests.TryAdd(messageId, tcs) then
                         do!
-                            model.rpcConsumer.Channel
+                            model
+                                .rpcConsumer
+                                .Channel
                                 .BasicPublishAsync(
                                     exchange = "",
                                     routingKey = routingKey,
                                     mandatory = true,
                                     basicProperties =
-                                        BasicProperties (
+                                        BasicProperties(
                                             ContentType = contentTypeStringFromContent message.Content,
                                             Persistent = false,
                                             MessageId = messageId,
                                             ReplyTo = "amq.rabbitmq.reply-to",
                                             Headers =
-                                                (message.Headers |> Map.map (fun _ v -> v :> obj) |> (Map.toSeq >> dict))
+                                                (message.Headers
+                                                 |> Map.map (fun _ v -> v :> obj)
+                                                 |> (Map.toSeq >> dict))
                                         ),
                                     body = bodyFromContent message.Content
                                 )
-                                .AsTask ()
+                                .AsTask()
                             |> Async.AwaitTask
 
                         let! result = tcs.Task |> (Async.AwaitTask >> Async.Catch)
@@ -884,12 +878,12 @@ module MqClient =
     /// <summary>Wrap callbacks with default implementation for OnRegistered,
     /// OnUnregistered, OnConsumerCancelled, OnShutdown. If any message is received
     /// for OnConsumerCancelled or OnShutdown the system will exit with error code 9</summary>
-    /// <param name="logError">Logger.</param>
+    /// <param name="logger">Logger.</param>
     /// <param name="onReceived">Callback that's called when a new message is received.</param>
     /// <returns>Callbacks</returns>
-    let terminateOnFailureWrapper: LogError -> (ReceivedMessage -> Async<unit>) -> Callbacks =
-        fun logError onReceived -> {
-            OnReceived =
+    let terminateOnFailureWrapper: ILogger -> (ReceivedMessage -> Async<unit>) -> Callbacks =
+        fun logger onReceived ->
+            { OnReceived =
                 fun message ->
                     // Something weird happens with exception handling when not
                     // using Async computational expression. Some exceptions are
@@ -897,25 +891,46 @@ module MqClient =
                     async {
                         try
                             do! onReceived message
-                        with exn ->
-                            logError (exn, $"💥 Unexpected error. %A{exn}\nShutting down", ())
+                        with
+                        | exn ->
+                            logger.LogError(exn, $"💥 Unexpected error. %A{exn}\nShutting down", ())
                             exit 9
                     }
 
-            OnRegistered = fun _ -> Async.singleton ()
+              OnRegistered = fun _ -> Async.singleton ()
 
-            OnUnregistered =
-                fun _ ->
-                    logError (null, "Got OnUnregistered event", ())
-                    exit 10
+              OnUnregistered =
 
-            OnConsumerCancelled =
-                fun _ ->
-                    logError (null, "Got OnConsumerCancelled event", ())
-                    exit 11
+                  fun event ->
+                      printfn $"{name} OnUnregistered"
+                      // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                      if event.replyCode <> Constants.ReplySuccess then
+                          logger.LogError(
+                              "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                              event.queueName,
+                              event.replyCode,
+                              event.replyText
+                          )
 
-            OnShutdown =
-                fun _ ->
-                    logError (null, "Got OnShutdown event", ())
-                    exit 12
-        }
+                          exit 11
+
+              OnConsumerCancelled =
+                  fun _ ->
+                      logger.LogError("Got OnConsumerCancelled event", ())
+                      exit 11
+
+              OnShutdown =
+                  fun event ->
+                      printfn $"{name} OnShutdown"
+                      // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                      if event.replyCode <> Constants.ReplySuccess then
+                          logger.LogError(
+                              "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                              event.queueName,
+                              event.replyCode,
+                              event.replyText
+                          )
+
+                          exit 13
+
+            }

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -13,10 +13,11 @@ module Connection =
 
     type OnConnectionShutdown = OnConnectionShutdownEvent -> unit
 
-    and OnConnectionShutdownEvent =
-        { connectionName: string
-          replyCode: int
-          replyText: string }
+    and OnConnectionShutdownEvent = {
+        connectionName: string
+        replyCode: int
+        replyText: string
+    }
 
     type CloseConnection = unit -> unit
 
@@ -25,7 +26,7 @@ module Connection =
         vhost: string
         endpoints: List<System.Uri>
     }
-    
+
     let initAsync
         (connectionConfig: ConnectionConfig)
         (onConnectionShutdown: OnConnectionShutdown)
@@ -33,37 +34,40 @@ module Connection =
         task {
             try
                 let factory =
-                    ConnectionFactory(
+                    ConnectionFactory (
                         AutomaticRecoveryEnabled = false,
                         RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
                         VirtualHost = connectionConfig.vhost
                     )
 
                 let! connection =
-                    factory.CreateConnectionAsync(
+                    factory.CreateConnectionAsync (
                         endpoints = List.map AmqpTcpEndpoint connectionConfig.endpoints,
                         clientProvidedName = connectionConfig.name
                     )
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
-                        onConnectionShutdown
-                            { connectionName = connectionConfig.name
-                              replyCode = int eventArgs.ReplyCode
-                              replyText = eventArgs.ReplyText }
-                    })
+                        onConnectionShutdown {
+                            connectionName = connectionConfig.name
+                            replyCode = int eventArgs.ReplyCode
+                            replyText = eventArgs.ReplyText
+                        }
+                    }
+                )
 
                 return
-                    Ok(
+                    Ok (
                         Connection connection,
                         (fun () ->
                             connection.AbortAsync connectionCloseTimeout
                             |> Async.AwaitTask
-                            |> Async.RunSynchronously)
+                            |> Async.RunSynchronously
+                        )
                     )
 
-            with
-            | exn -> return Error $"%s{connectionConfig.name}: Failed to connect to RabbitMQ: %s{string exn}"
+            with exn ->
+                return Error $"%s{connectionConfig.name}: Failed to connect to RabbitMQ: %s{string exn}"
         }
         |> Async.AwaitTask
 
@@ -72,10 +76,10 @@ module Connection =
         fun event ->
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
-                logger.LogWarning("Closing RabbitMQ connection {connectionName}", event.connectionName)
+                logger.LogWarning ("Closing RabbitMQ connection {connectionName}", event.connectionName)
 
             else if event.replyCode <> Constants.ReplySuccess then
-                logger.LogError(
+                logger.LogError (
                     "Got unexpected event `Shutdown` on connection {connectionName}. {replyCode} - {replyText}. Will terminate the process",
                     event.connectionName,
                     event.replyCode,
@@ -90,62 +94,54 @@ module Consumer =
 
     type ReceivedMessage = private ReceivedMessage of BasicDeliverEventArgs * AsyncEventingBasicConsumer
 
-    type Callbacks =
-        { onReceived: ReceivedMessage -> Async<unit>
-          onRegistered: string -> unit
-          onUnregistered: UnregisteredEvent -> unit
-          onShutdown: UnregisteredEvent -> unit }
+    type Callbacks = {
+        onReceived: ReceivedMessage -> Async<unit>
+        onRegistered: string -> unit
+        onUnregistered: UnregisteredEvent -> unit
+        onShutdown: UnregisteredEvent -> unit
+    }
 
-    and UnregisteredEvent =
-        { queueName: string
-          replyCode: int
-          replyText: string }
+    and UnregisteredEvent = {
+        queueName: string
+        replyCode: int
+        replyText: string
+    }
 
-    and QueueConfig =
-        { queueName: string
-          bindToExchange: Option<string>
-          callbacks: Callbacks
-          messageTimeToLive: Option<int>
-          /// Maximum number of unacked messages to be fetched at once. The messages will still be processed one at a time.
-          prefetchCount: uint16
-          queueType: QueueType }
+    and QueueConfig = {
+        queueName: string
+        bindToExchange: Option<string>
+        callbacks: Callbacks
+        messageTimeToLive: Option<int>
+        /// Maximum number of unacked messages to be fetched at once. The messages will still be processed one at a time.
+        prefetchCount: uint16
+        queueType: QueueType
+    }
 
     and QueueType =
         | Quorum
         /// Deprecated. Use `Quorum` instead.
         | Classic
 
-
-    type ReplyMessage =
-        { headers: List<string * string>
-          body: ReplyBody }
+    type ReplyMessage = {
+        headers: List<string * string>
+        body: ReplyBody
+    }
 
     and ReplyBody = Json of string
 
     let ackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
-        consumer
-            .Channel
-            .BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false)
-            .AsTask()
+        consumer.Channel.BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false).AsTask ()
         |> Async.AwaitTask
 
     let nackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
-        consumer
-            .Channel
-            .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
-            .AsTask()
+        consumer.Channel.BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true).AsTask ()
         |> Async.AwaitTask
 
     /// The consumed message will be nacked after a specified delay. Will return after waiting for the delay.
     let private nackWithDelayBlockingAsync (delay: System.TimeSpan) : ReceivedMessage -> Async<unit> =
         fun message ->
             async {
-                do!
-                    Async.Sleep(
-                        int delay.TotalMilliseconds
-                        |> max 0
-                        |> min System.Int32.MaxValue
-                    )
+                do! Async.Sleep (int delay.TotalMilliseconds |> max 0 |> min System.Int32.MaxValue)
 
                 return! nackAsync message
             }
@@ -156,9 +152,7 @@ module Consumer =
             async {
                 // `StartChild` means we share the same `cancellation token`,
                 // so any exceptions should be propagated back to this call.
-                let! _ =
-                    nackWithDelayBlockingAsync delay message
-                    |> Async.StartChild
+                let! _ = nackWithDelayBlockingAsync delay message |> Async.StartChild
 
                 return ()
             }
@@ -181,7 +175,7 @@ module Consumer =
                 | _, null -> return Error "Missing message_id property."
 
                 | replyTo, correlationId ->
-                    let messageId = System.Guid.NewGuid().ToString()
+                    let messageId = System.Guid.NewGuid().ToString ()
 
                     let contentType, body =
                         match replyMessage.body with
@@ -194,14 +188,14 @@ module Consumer =
                         |> dict
 
                     do!
-                        consumer.Channel.BasicPublishAsync(
+                        consumer.Channel.BasicPublishAsync (
                             exchange = "",
                             routingKey = replyTo,
                             // mandatory should be false when publishing to a direct-reply-to queue (https://www.rabbitmq.com/direct-reply-to.html#limitations)
                             // which is a very common use case for replies.
                             mandatory = false,
                             basicProperties =
-                                BasicProperties(
+                                BasicProperties (
                                     ContentType = contentType,
                                     Persistent = true,
                                     MessageId = messageId,
@@ -211,10 +205,10 @@ module Consumer =
                             body = body
                         )
 
-                    return Ok()
+                    return Ok ()
 
-            with
-            | exn -> return Error(string exn)
+            with exn ->
+                return Error (string exn)
         }
         |> Async.AwaitTask
 
@@ -223,22 +217,23 @@ module Consumer =
     let initAsync (config: QueueConfig) (Connection connection: Connection) : Async<Result<Model, string>> =
         task {
             try
-                let! channel = connection.CreateChannelAsync()
+                let! channel = connection.CreateChannelAsync ()
 
-                do! channel.BasicQosAsync(uint32 0, config.prefetchCount, false)
+                do! channel.BasicQosAsync (uint32 0, config.prefetchCount, false)
 
                 channel.add_CallbackExceptionAsync (fun _ _ ->
                     task {
                         do!
-                            connection.AbortAsync(
+                            connection.AbortAsync (
                                 uint16 Constants.ChannelError,
                                 "RabbitMqClient.Consumer: Unhandled channel exception, closing connection",
                                 connectionCloseTimeout
                             )
-                    })
+                    }
+                )
 
                 let! _ =
-                    channel.QueueDeclareAsync(
+                    channel.QueueDeclareAsync (
                         queue = config.queueName,
                         durable = true,
                         exclusive = false,
@@ -258,7 +253,7 @@ module Consumer =
 
                 if Option.isSome config.bindToExchange then
                     do!
-                        channel.QueueBindAsync(
+                        channel.QueueBindAsync (
                             queue = config.queueName,
                             exchange = config.bindToExchange.Value,
                             routingKey = "*",
@@ -268,47 +263,51 @@ module Consumer =
                 let consumer = AsyncEventingBasicConsumer channel
 
                 let consumerTag =
-                    $"%s{config.queueName}-consumer-%s{System.Guid.NewGuid().ToString()}"
+                    $"%s{config.queueName}-consumer-%s{System.Guid.NewGuid().ToString ()}"
 
                 consumer.add_ReceivedAsync (fun _ event ->
                     task {
                         if event.ConsumerTag = consumerTag then
-                            do! config.callbacks.onReceived (ReceivedMessage(event, consumer))
-                    })
+                            do! config.callbacks.onReceived (ReceivedMessage (event, consumer))
+                    }
+                )
 
                 consumer.add_RegisteredAsync (fun _ eventArgs ->
                     task {
-                        if eventArgs.ConsumerTags
-                           |> Array.contains consumerTag then
+                        if eventArgs.ConsumerTags |> Array.contains consumerTag then
                             config.callbacks.onRegistered config.queueName
-                    })
+                    }
+                )
 
                 consumer.add_UnregisteredAsync (fun _ eventArgs ->
                     task {
-                        if eventArgs.ConsumerTags
-                           |> Array.contains consumerTag then
+                        if eventArgs.ConsumerTags |> Array.contains consumerTag then
                             let replyCode, replyText =
                                 if consumer.ShutdownReason = null then
                                     0, "Missing ShutdownReason. Did the queue got deleted?"
                                 else
                                     int consumer.ShutdownReason.ReplyCode, consumer.ShutdownReason.ReplyText
 
-                            config.callbacks.onUnregistered
-                                { queueName = config.queueName
-                                  replyCode = replyCode
-                                  replyText = replyText }
-                    })
+                            config.callbacks.onUnregistered {
+                                queueName = config.queueName
+                                replyCode = replyCode
+                                replyText = replyText
+                            }
+                    }
+                )
 
                 consumer.add_ShutdownAsync (fun _ eventArgs ->
                     task {
-                        config.callbacks.onShutdown
-                            { queueName = config.queueName
-                              replyCode = int eventArgs.ReplyCode
-                              replyText = eventArgs.ReplyText }
-                    })
+                        config.callbacks.onShutdown {
+                            queueName = config.queueName
+                            replyCode = int eventArgs.ReplyCode
+                            replyText = eventArgs.ReplyText
+                        }
+                    }
+                )
 
                 let! _ =
-                    channel.BasicConsumeAsync(
+                    channel.BasicConsumeAsync (
                         queue = config.queueName,
                         autoAck = false,
                         consumerTag = consumerTag,
@@ -318,10 +317,9 @@ module Consumer =
                         consumer = consumer
                     )
 
-                return Ok(Consumer consumer)
+                return Ok (Consumer consumer)
 
-            with
-            | exn ->
+            with exn ->
                 // Abort connection gracefully on any unexpected error.
                 do! connection.AbortAsync connectionCloseTimeout
 
@@ -333,52 +331,55 @@ module Consumer =
     /// <param name="logger">Logger.</param>
     /// <param name="onReceivedAsync">Callback that's called when a new message is received.</param>
     /// <returns>Callbacks</returns>
-    let terminateOnUnexpectedEvents (logger: ILogger) (onReceivedAsync: ReceivedMessage -> Async<unit>) : Callbacks =
-        { onReceived =
+    let terminateOnUnexpectedEvents (logger: ILogger) (onReceivedAsync: ReceivedMessage -> Async<unit>) : Callbacks = {
+        onReceived =
             fun message ->
                 async {
                     try
                         do! onReceivedAsync message
-                    with
-                    | exn ->
-                        logger.LogError(exn, "Got unexpected error during event `Received`. Will terminate the process")
+                    with exn ->
+                        logger.LogError (
+                            exn,
+                            "Got unexpected error during event `Received`. Will terminate the process"
+                        )
 
                         exit 9
                 }
 
-          onRegistered = fun queueName -> logger.LogInformation("Consumer registered on queue {queueName}", queueName)
+        onRegistered = fun queueName -> logger.LogInformation ("Consumer registered on queue {queueName}", queueName)
 
-          onUnregistered =
-              fun event ->
-                  // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
-                  if event.replyCode <> Constants.ReplySuccess then
-                      logger.LogError(
-                          "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
-                          event.queueName,
-                          event.replyCode,
-                          event.replyText
-                      )
+        onUnregistered =
+            fun event ->
+                // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                if event.replyCode <> Constants.ReplySuccess then
+                    logger.LogError (
+                        "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                        event.queueName,
+                        event.replyCode,
+                        event.replyText
+                    )
 
-                      exit 11
+                    exit 11
 
-          onShutdown =
-              fun event ->
-                  // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
-                  if event.replyCode = Constants.ReplySuccess then
-                      logger.LogInformation(
-                          "Got expected event `Shutdown` for consumer on queue {queueName}",
-                          event.queueName
-                      )
+        onShutdown =
+            fun event ->
+                // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                if event.replyCode = Constants.ReplySuccess then
+                    logger.LogInformation (
+                        "Got expected event `Shutdown` for consumer on queue {queueName}",
+                        event.queueName
+                    )
 
-                  else
-                      logger.LogError(
-                          "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
-                          event.queueName,
-                          event.replyCode,
-                          event.replyText
-                      )
+                else
+                    logger.LogError (
+                        "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                        event.queueName,
+                        event.replyCode,
+                        event.replyText
+                    )
 
-                      exit 13 }
+                    exit 13
+    }
 
 module RPC =
     open System.Threading
@@ -388,17 +389,19 @@ module RPC =
 
     and RequestAsync = RequestMessage -> Async<Result<ResponseMessage, string>>
 
-    and RequestMessage =
-        { queue: string
-          headers: List<string * string>
-          body: RequestBody
-          timeout: System.TimeSpan }
+    and RequestMessage = {
+        queue: string
+        headers: List<string * string>
+        body: RequestBody
+        timeout: System.TimeSpan
+    }
 
     and RequestBody = Json of string
 
-    and ResponseMessage =
-        { body: string
-          headers: System.Collections.Generic.IDictionary<string, obj> }
+    and ResponseMessage = {
+        body: string
+        headers: System.Collections.Generic.IDictionary<string, obj>
+    }
 
     type private CorrelationId = string
 
@@ -411,19 +414,19 @@ module RPC =
     let private requestAsync (pendingRequests: PendingRequests) (consumer: AsyncEventingBasicConsumer) : RequestAsync =
         fun message ->
             task {
-                let messageId = System.Guid.NewGuid().ToString()
+                let messageId = System.Guid.NewGuid().ToString ()
 
-                let completionSource = TaskCompletionSource<_>()
+                let completionSource = TaskCompletionSource<_> ()
 
-                use cancellationSource = new CancellationTokenSource(message.timeout)
+                use cancellationSource = new CancellationTokenSource (message.timeout)
 
                 let cancellationCallback () =
                     // Ensure the  pending request is removed to prevent memory leaks.
                     pendingRequests.TryRemove messageId |> ignore
 
                     // Try set error result.
-                    completionSource.TrySetResult(
-                        $"Request to queue '%s{message.queue}' timed out after %s{message.timeout.TotalSeconds.ToString()}s"
+                    completionSource.TrySetResult (
+                        $"Request to queue '%s{message.queue}' timed out after %s{message.timeout.TotalSeconds.ToString ()}s"
                         |> Error
                     )
                     |> ignore
@@ -431,30 +434,27 @@ module RPC =
                 // On received reply we will return from this function and `Dispose` will be called.
                 // `Dispose` will cancel the call to the callback.
                 use _cancellationRegistration =
-                    cancellationSource.Token.Register(
+                    cancellationSource.Token.Register (
                         callback = cancellationCallback,
                         useSynchronizationContext = false
                     )
 
                 try
-                    if pendingRequests.TryAdd(messageId, completionSource) then
+                    if pendingRequests.TryAdd (messageId, completionSource) then
                         let contentType, requestBody =
                             match message.body with
                             | Json json -> "application/json", System.Text.Encoding.UTF8.GetBytes json
 
-                        let requestHeaders =
-                            message.headers
-                            |> Seq.map (fun (k, v) -> k, v :> obj)
-                            |> dict
+                        let requestHeaders = message.headers |> Seq.map (fun (k, v) -> k, v :> obj) |> dict
 
                         do!
-                            consumer.Channel.BasicPublishAsync(
+                            consumer.Channel.BasicPublishAsync (
                                 exchange = "",
                                 routingKey = message.queue,
                                 // We don't care if the reply message got routed or not as we're using timeout.
                                 mandatory = false,
                                 basicProperties =
-                                    BasicProperties(
+                                    BasicProperties (
                                         ContentType = contentType,
                                         Persistent = false,
                                         MessageId = messageId,
@@ -469,8 +469,8 @@ module RPC =
                     else
                         return Error $"RabbitMqClient.RPC.request: Duplicate message id %s{messageId}"
 
-                with
-                | exn -> return Error(string exn)
+                with exn ->
+                    return Error (string exn)
             }
             |> Async.AwaitTask
 
@@ -481,25 +481,26 @@ module RPC =
         : Async<Result<Client, string>> =
         task {
             try
-                let pendingRequests: PendingRequests = ConcurrentDictionary()
+                let pendingRequests: PendingRequests = ConcurrentDictionary ()
 
                 let consumerTag =
                     queueDirectReplyTo
                     + "-"
                     + clientName
                     + "-consumer-"
-                    + System.Guid.NewGuid().ToString()
+                    + System.Guid.NewGuid().ToString ()
 
-                let! channel = connection.CreateChannelAsync()
+                let! channel = connection.CreateChannelAsync ()
 
                 channel.add_CallbackExceptionAsync (fun _ eventArgs ->
                     task {
                         let reason = $"%s{clientName}: Unhandled channel exception, closing connection"
 
-                        logger.LogError(eventArgs.Exception, reason)
+                        logger.LogError (eventArgs.Exception, reason)
 
-                        do! connection.AbortAsync(uint16 Constants.ChannelError, reason, connectionCloseTimeout)
-                    })
+                        do! connection.AbortAsync (uint16 Constants.ChannelError, reason, connectionCloseTimeout)
+                    }
+                )
 
                 let consumer = AsyncEventingBasicConsumer channel
 
@@ -509,33 +510,36 @@ module RPC =
 
                         match pendingRequests.TryRemove correlationId with
                         | true, tcs ->
-                            let responseMessage: ResponseMessage =
-                                { body = System.Text.Encoding.UTF8.GetString eventArgs.Body.Span
-                                  headers = eventArgs.BasicProperties.Headers }
+                            let responseMessage: ResponseMessage = {
+                                body = System.Text.Encoding.UTF8.GetString eventArgs.Body.Span
+                                headers = eventArgs.BasicProperties.Headers
+                            }
 
-                            if not (tcs.TrySetResult(Ok responseMessage)) then
-                                logger.LogWarning(
+                            if not (tcs.TrySetResult (Ok responseMessage)) then
+                                logger.LogWarning (
                                     "Consumer {clientName} received reply but unable to set task completion source with correlation id {correlationId}",
                                     clientName,
                                     correlationId
                                 )
 
                         | _ ->
-                            logger.LogWarning(
+                            logger.LogWarning (
                                 "Consumer {clientName} received reply without known correlation id: {correlationId}",
                                 clientName,
                                 correlationId
                             )
-                    })
+                    }
+                )
 
                 consumer.add_RegisteredAsync (fun _ eventArgs ->
                     task {
-                        logger.LogInformation(
+                        logger.LogInformation (
                             "Consumer {clientName} registered {consumerTags}",
                             clientName,
                             eventArgs.ConsumerTags
                         )
-                    })
+                    }
+                )
 
                 consumer.add_UnregisteredAsync (fun _ eventArgs ->
                     task {
@@ -547,29 +551,31 @@ module RPC =
 
                         // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
                         if replyCode <> Constants.ReplySuccess then
-                            logger.LogWarning(
+                            logger.LogWarning (
                                 "Consumer {clientName} unregistered {consumerTags}",
                                 clientName,
                                 eventArgs.ConsumerTags
                             )
-                    })
+                    }
+                )
 
                 consumer.add_ShutdownAsync (fun _ eventArgs ->
                     task {
                         if eventArgs.ReplyCode = uint16 Constants.ReplySuccess then
-                            logger.LogInformation("Got expected event `Shutdown` for {clientName}", clientName)
+                            logger.LogInformation ("Got expected event `Shutdown` for {clientName}", clientName)
 
                         else
-                            logger.LogWarning(
+                            logger.LogWarning (
                                 "Get unexpected event `Shutdown` for {clientName}. {replyCode} - {replyText}",
                                 clientName,
                                 eventArgs.ReplyCode,
                                 eventArgs.ReplyText
                             )
-                    })
+                    }
+                )
 
                 let! _ =
-                    channel.BasicConsumeAsync(
+                    channel.BasicConsumeAsync (
                         queue = queueDirectReplyTo,
                         autoAck = true, // Must be true for direct-reply-to.
                         consumerTag = consumerTag,
@@ -579,9 +585,12 @@ module RPC =
                         consumer = consumer
                     )
 
-                return Ok { requestAsync = requestAsync pendingRequests consumer }
+                return
+                    Ok {
+                        requestAsync = requestAsync pendingRequests consumer
+                    }
 
-            with
-            | exn -> return Error(string exn)
+            with exn ->
+                return Error (string exn)
         }
         |> Async.AwaitTask

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -286,7 +286,7 @@ module Consumer =
                         if eventArgs.ConsumerTags |> Array.contains consumerTag then
                             let replyCode, replyText =
                                 if consumer.ShutdownReason = null then
-                                    0, "Missing ShutdownReason. Did the queue got deleted?"
+                                    0, "Missing ShutdownReason. Was the queue deleted?"
                                 else
                                     int consumer.ShutdownReason.ReplyCode, consumer.ShutdownReason.ReplyText
 
@@ -431,7 +431,8 @@ module RPC =
             task {
                 let messageId = System.Guid.NewGuid().ToString ()
 
-                let completionSource = TaskCompletionSource<_> ()
+                let completionSource =
+                    TaskCompletionSource<_> TaskCreationOptions.RunContinuationsAsynchronously
 
                 use cancellationSource = new CancellationTokenSource (message.timeout)
 
@@ -581,7 +582,7 @@ module RPC =
 
                         else
                             logger.LogWarning (
-                                "Get unexpected event `Shutdown` for {clientName}. {replyCode} - {replyText}",
+                                "Got unexpected event `Shutdown` for {clientName}. {replyCode} - {replyText}",
                                 clientName,
                                 eventArgs.ReplyCode,
                                 eventArgs.ReplyText
@@ -655,7 +656,7 @@ module Publish =
     // https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1818
     // https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/87a4788e54cfb0745dd7b6e6a3456c2e1fa23b23/projects/Applications/PublisherConfirms/PublisherConfirms.cs
     // https://github.com/lukebakken/rabbitmq-dotnet-client-1721/blob/eae2aff74d2f2eca2e3e32e3d1a5f01aee461ef8/Program.cs
-    let private publicAsync (clientName: string) (channel: IChannel) : PublishAsync =
+    let private publishAsync (clientName: string) (channel: IChannel) : PublishAsync =
         fun message ->
             task {
                 let messageId = System.Guid.NewGuid().ToString ()
@@ -725,7 +726,7 @@ module Publish =
 
                 return
                     Ok {
-                        publishAsync = publicAsync clientName channel
+                        publishAsync = publishAsync clientName channel
                     }
 
             with exn ->

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -28,7 +28,7 @@ module Connection =
     }
 
     let initAsync
-        (connectionConfig: ConnectionConfig)
+        (config: ConnectionConfig)
         (onConnectionShutdown: OnConnectionShutdown)
         : Async<Result<Connection * CloseConnection, string>> =
         task {
@@ -37,19 +37,19 @@ module Connection =
                     ConnectionFactory (
                         AutomaticRecoveryEnabled = false,
                         RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
-                        VirtualHost = connectionConfig.vhost
+                        VirtualHost = config.vhost
                     )
 
                 let! connection =
                     factory.CreateConnectionAsync (
-                        endpoints = List.map AmqpTcpEndpoint connectionConfig.endpoints,
-                        clientProvidedName = connectionConfig.name
+                        endpoints = List.map AmqpTcpEndpoint config.endpoints,
+                        clientProvidedName = config.name
                     )
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
                         onConnectionShutdown {
-                            connectionName = connectionConfig.name
+                            connectionName = config.name
                             replyCode = int eventArgs.ReplyCode
                             replyText = eventArgs.ReplyText
                         }
@@ -67,7 +67,7 @@ module Connection =
                     )
 
             with exn ->
-                return Error $"%s{connectionConfig.name}: Failed to connect to RabbitMQ: %s{string exn}"
+                return Error $"%s{config.name}: Failed to connect to RabbitMQ: %s{string exn}"
         }
         |> Async.AwaitTask
 
@@ -90,7 +90,7 @@ module Connection =
 
 module Consumer =
 
-    type Model = private Consumer of AsyncEventingBasicConsumer
+    type Consumer = private Consumer of AsyncEventingBasicConsumer
 
     type ReceivedMessage = private ReceivedMessage of BasicDeliverEventArgs * AsyncEventingBasicConsumer
 
@@ -173,8 +173,8 @@ module Consumer =
         task {
             try
                 match eventArgs.BasicProperties.ReplyTo, eventArgs.BasicProperties.MessageId with
-                | null, _ -> return Error "Missing reply_to property."
-                | _, null -> return Error "Missing message_id property."
+                | null, _ -> return Error "Missing reply_to property"
+                | _, null -> return Error "Missing message_id property"
 
                 | replyTo, correlationId ->
                     let messageId = System.Guid.NewGuid().ToString ()
@@ -184,18 +184,17 @@ module Consumer =
                         | Json jsonContent -> "application/json", System.Text.Encoding.UTF8.GetBytes jsonContent
                         | Binary data -> "application/octet-stream", data
 
-                    let publishWithHeaders =
+                    let headers =
                         // `sequence_end` is required by rabbot (foo-foo-mq) clients (https://github.com/arobson/rabbot/issues/76).
                         ("sequence_end", "true") :: replyMessage.headers
-                        |> Seq.map (fun (k, v) -> k, v :> obj)
-                        |> dict
+                        |> Seq.map System.Collections.Generic.KeyValuePair<string, obj>
+                        |> System.Collections.Generic.Dictionary
 
                     do!
                         consumer.Channel.BasicPublishAsync (
                             exchange = "",
                             routingKey = replyTo,
-                            // mandatory should be false when publishing to a direct-reply-to queue (https://www.rabbitmq.com/direct-reply-to.html#limitations)
-                            // which is a very common use case for replies.
+                            // `mandatory` should be false when publishing to a direct-reply-to queue (https://www.rabbitmq.com/direct-reply-to.html#limitations).
                             mandatory = false,
                             basicProperties =
                                 BasicProperties (
@@ -203,7 +202,7 @@ module Consumer =
                                     Persistent = true,
                                     MessageId = messageId,
                                     CorrelationId = correlationId,
-                                    Headers = publishWithHeaders
+                                    Headers = headers
                                 ),
                             body = body
                         )
@@ -217,7 +216,7 @@ module Consumer =
 
     /// <summary>Declares and optionally binds the specified queue, then starts consuming messages.</summary>
     /// <param name="config">Queue configuration.</param>
-    let initAsync (config: QueueConfig) (Connection connection: Connection) : Async<Result<Model, string>> =
+    let initAsync (config: QueueConfig) (Connection connection: Connection) : Async<Result<Consumer, string>> =
         task {
             try
                 let! channel = connection.CreateChannelAsync ()
@@ -259,7 +258,7 @@ module Consumer =
                         channel.QueueBindAsync (
                             queue = config.queueName,
                             exchange = config.bindToExchange.Value,
-                            routingKey = "*",
+                            routingKey = "*", // TODO: Should be move this to config now, as this is really opinionated.
                             arguments = null
                         )
 
@@ -323,7 +322,7 @@ module Consumer =
                 return Ok (Consumer consumer)
 
             with exn ->
-                // Abort connection gracefully on any unexpected error.
+                // Abort connection gracefully on any unexpected error. TODO: Remove this? Move to Program?
                 do! connection.AbortAsync connectionCloseTimeout
 
                 return Error $"RabbitMqClient.Consumer: %s{string exn}"
@@ -385,8 +384,8 @@ module Consumer =
     }
 
 module RPC =
-    open System.Threading
     open System.Collections.Concurrent
+    open System.Threading
 
     type RequestMessage = {
         queue: string
@@ -464,13 +463,16 @@ module RPC =
                             match message.body with
                             | Json json -> "application/json", System.Text.Encoding.UTF8.GetBytes json
 
-                        let requestHeaders = message.headers |> Seq.map (fun (k, v) -> k, v :> obj) |> dict
+                        let requestHeaders =
+                            message.headers
+                            |> Seq.map System.Collections.Generic.KeyValuePair<string, obj>
+                            |> System.Collections.Generic.Dictionary
 
                         do!
                             consumer.Channel.BasicPublishAsync (
                                 exchange = "",
                                 routingKey = message.queue,
-                                // We don't care if the reply message got routed or not as we're using timeout.
+                                // We don't care if the request message got routed or not as we're using timeout.
                                 mandatory = false,
                                 basicProperties =
                                     BasicProperties (
@@ -488,7 +490,7 @@ module RPC =
                         | Ok response -> return Ok (mapResponse response.BasicProperties.Headers response.Body)
 
                     else
-                        return Error $"RabbitMqClient.RPC.request: Duplicate message id %s{messageId}"
+                        return Error $"RabbitMqClient.RPC: Duplicate message id %s{messageId}"
 
                 with exn ->
                     return Error (string exn)
@@ -641,6 +643,7 @@ module RPC =
             | _ -> None
 
 module Publish =
+
     type PublishMessage = {
         queue: string
         headers: List<string * string>
@@ -648,7 +651,7 @@ module Publish =
         timeout: System.TimeSpan
     }
 
-    // TODO: Share with RPC?
+    // TODO: Share with Consumer/RPC?
     and PublishMessageBody = Json of string
 
     type PublishAsync = PublishMessage -> Async<Result<unit, string>>
@@ -683,7 +686,7 @@ module Publish =
                             exchange = "",
                             routingKey = message.queue,
                             body = publishBody,
-                            mandatory = true, // If queue doesn't exist at the broker, a "basic return" is replied.
+                            mandatory = true, // If the queue doesn't exist, a `basic return` is replied.
                             basicProperties =
                                 BasicProperties (
                                     ContentType = contentType,
@@ -697,7 +700,8 @@ module Publish =
                     return Ok ()
 
                 with exn ->
-                    return Error $"%s{clientName}: Publish exception. Details: %s{string exn}"
+                    // `BasicPublishAsync` with `publisherConfirmationsEnabled` and `publisherConfirmationTrackingEnabled` indicates `nack` or `basic return` by throwing.
+                    return Error $"%s{clientName}: Failed to publish to queue. Details: %s{string exn}"
             }
             |> Async.AwaitTask
 

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -653,8 +653,8 @@ module Publish =
 
     // References:
     // https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1818
-    // https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/main/projects/Applications/PublisherConfirms/PublisherConfirms.cs
-    // https://github.com/lukebakken/rabbitmq-dotnet-client-1721/blob/main/Program.cs
+    // https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/87a4788e54cfb0745dd7b6e6a3456c2e1fa23b23/projects/Applications/PublisherConfirms/PublisherConfirms.cs
+    // https://github.com/lukebakken/rabbitmq-dotnet-client-1721/blob/eae2aff74d2f2eca2e3e32e3d1a5f01aee461ef8/Program.cs
     let private publicAsync (clientName: string) (channel: IChannel) : PublishAsync =
         fun message ->
             task {

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -639,3 +639,99 @@ module RPC =
                 | _ -> None
 
             | _ -> None
+
+module Publish =
+    type PublishMessage = {
+        queue: string
+        headers: List<string * string>
+        body: PublishMessageBody
+        timeout: System.TimeSpan
+    }
+
+    // TODO: Share with RPC?
+    and PublishMessageBody = Json of string
+
+    type PublishAsync = PublishMessage -> Async<Result<unit, string>>
+
+    type Client = { publishAsync: PublishAsync }
+
+    // References:
+    // https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1818
+    // https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/main/projects/Applications/PublisherConfirms/PublisherConfirms.cs
+    // https://github.com/lukebakken/rabbitmq-dotnet-client-1721/blob/main/Program.cs
+    let private publicAsync (clientName: string) (channel: IChannel) : PublishAsync =
+        fun message ->
+            task {
+                let messageId = System.Guid.NewGuid().ToString ()
+
+                let contentType, publishBody =
+                    match message.body with
+                    | Json jsonString -> "application/json", System.Text.Encoding.UTF8.GetBytes jsonString
+
+                // The IDictionary implementation must be mutable due to we're using `publisherConfirmationTrackingEnabled`
+                // which adds the header `x-dotnet-pub-seq-no` in the `BasicPublishAsync` call.
+                let requestHeaders =
+                    message.headers
+                    |> Seq.map System.Collections.Generic.KeyValuePair<string, obj>
+                    |> System.Collections.Generic.Dictionary
+
+                try
+                    use cts = new System.Threading.CancellationTokenSource (message.timeout)
+
+                    do!
+                        channel.BasicPublishAsync (
+                            exchange = "",
+                            routingKey = message.queue,
+                            body = publishBody,
+                            mandatory = true, // If queue doesn't exist at the broker, a "basic return" is replied.
+                            basicProperties =
+                                BasicProperties (
+                                    ContentType = contentType,
+                                    Persistent = true,
+                                    MessageId = messageId,
+                                    Headers = requestHeaders
+                                ),
+                            cancellationToken = cts.Token
+                        )
+
+                    return Ok ()
+
+                with exn ->
+                    return Error $"%s{clientName}: Publish exception. Details: %s{string exn}"
+            }
+            |> Async.AwaitTask
+
+    let initAsync
+        (logger: ILogger)
+        (clientName: string)
+        (Connection connection: Connection)
+        : Async<Result<Client, string>> =
+        task {
+            try
+                let! channel =
+                    connection.CreateChannelAsync (
+                        CreateChannelOptions (
+                            publisherConfirmationsEnabled = true,
+                            publisherConfirmationTrackingEnabled = true
+                        )
+                    )
+
+                channel.add_CallbackExceptionAsync (fun _ eventArgs ->
+                    task {
+                        let reason = $"%s{clientName}: Unhandled channel exception, closing connection"
+
+                        logger.LogError (eventArgs.Exception, reason)
+
+                        do! connection.AbortAsync (uint16 Constants.ChannelError, reason, connectionCloseTimeout)
+                    }
+                )
+
+                return
+                    Ok {
+                        publishAsync = publicAsync clientName channel
+                    }
+
+            with exn ->
+                return Error (string exn)
+        }
+        |> Async.AwaitTask

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -127,7 +127,9 @@ module Consumer =
         body: ReplyBody
     }
 
-    and ReplyBody = Json of string
+    and ReplyBody =
+        | Json of string
+        | Binary of byte array
 
     let ackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
         consumer.Channel.BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false).AsTask ()
@@ -180,6 +182,7 @@ module Consumer =
                     let contentType, body =
                         match replyMessage.body with
                         | Json jsonContent -> "application/json", System.Text.Encoding.UTF8.GetBytes jsonContent
+                        | Binary data -> "application/octet-stream", data
 
                     let publishWithHeaders =
                         // `sequence_end` is required by rabbot (foo-foo-mq) clients (https://github.com/arobson/rabbot/issues/76).

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -1,4 +1,4 @@
-module Insurello.RabbitMqClient
+module Insurello.RabbitMqClient.RabbitMqClient
 
 open Microsoft.Extensions.Logging
 open RabbitMQ.Client
@@ -13,56 +13,57 @@ module Connection =
 
     type OnConnectionShutdown = OnConnectionShutdownEvent -> unit
 
-    and OnConnectionShutdownEvent = {
-        connectionName: string
-        replyCode: int
-        replyText: string
-    }
+    and OnConnectionShutdownEvent =
+        { connectionName: string
+          replyCode: int
+          replyText: string }
 
     type CloseConnection = unit -> unit
 
+    type ConnectionConfig = {
+        name: string
+        vhost: string
+        endpoints: List<System.Uri>
+    }
+    
     let initAsync
-        (connectionName: string)
-        (endpoints: List<System.Uri>)
+        (connectionConfig: ConnectionConfig)
         (onConnectionShutdown: OnConnectionShutdown)
         : Async<Result<Connection * CloseConnection, string>> =
         task {
             try
                 let factory =
-                    ConnectionFactory (
+                    ConnectionFactory(
                         AutomaticRecoveryEnabled = false,
                         RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
-                        VirtualHost = "quorum-vhost"
+                        VirtualHost = connectionConfig.vhost
                     )
 
                 let! connection =
-                    factory.CreateConnectionAsync (
-                        endpoints = List.map AmqpTcpEndpoint endpoints,
-                        clientProvidedName = connectionName
+                    factory.CreateConnectionAsync(
+                        endpoints = List.map AmqpTcpEndpoint connectionConfig.endpoints,
+                        clientProvidedName = connectionConfig.name
                     )
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
-                        onConnectionShutdown {
-                            connectionName = connectionName
-                            replyCode = int eventArgs.ReplyCode
-                            replyText = eventArgs.ReplyText
-                        }
-                    }
-                )
+                        onConnectionShutdown
+                            { connectionName = connectionConfig.name
+                              replyCode = int eventArgs.ReplyCode
+                              replyText = eventArgs.ReplyText }
+                    })
 
                 return
-                    Ok (
+                    Ok(
                         Connection connection,
                         (fun () ->
                             connection.AbortAsync connectionCloseTimeout
                             |> Async.AwaitTask
-                            |> Async.RunSynchronously
-                        )
+                            |> Async.RunSynchronously)
                     )
 
-            with exn ->
-                return Error $"%s{connectionName}: Failed to connect to RabbitMQ: %s{string exn}"
+            with
+            | exn -> return Error $"%s{connectionConfig.name}: Failed to connect to RabbitMQ: %s{string exn}"
         }
         |> Async.AwaitTask
 
@@ -71,10 +72,10 @@ module Connection =
         fun event ->
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
-                logger.LogWarning ("Closing RabbitMQ connection {connectionName}", event.connectionName)
+                logger.LogWarning("Closing RabbitMQ connection {connectionName}", event.connectionName)
 
             else if event.replyCode <> Constants.ReplySuccess then
-                logger.LogError (
+                logger.LogError(
                     "Got unexpected event `Shutdown` on connection {connectionName}. {replyCode} - {replyText}. Will terminate the process",
                     event.connectionName,
                     event.replyCode,
@@ -89,61 +90,63 @@ module Consumer =
 
     type ReceivedMessage = private ReceivedMessage of BasicDeliverEventArgs * AsyncEventingBasicConsumer
 
-    type Callbacks = {
-        onReceived: ReceivedMessage -> Async<unit>
-        onRegistered: string -> unit
-        onUnregistered: UnregisteredEvent -> unit
-        onShutdown: UnregisteredEvent -> unit
-    }
+    type Callbacks =
+        { onReceived: ReceivedMessage -> Async<unit>
+          onRegistered: string -> unit
+          onUnregistered: UnregisteredEvent -> unit
+          onShutdown: UnregisteredEvent -> unit }
 
-    and UnregisteredEvent = {
-        queueName: string
-        replyCode: int
-        replyText: string
-    }
+    and UnregisteredEvent =
+        { queueName: string
+          replyCode: int
+          replyText: string }
 
-    and QueueConfig = {
-        queueName: string
-        bindToExchange: Option<string>
-        callbacks: Callbacks
-        messageTimeToLive: Option<int>
-        queueType: QueueType
-    }
+    and QueueConfig =
+        { queueName: string
+          bindToExchange: Option<string>
+          callbacks: Callbacks
+          messageTimeToLive: Option<int>
+          /// Maximum number of unacked messages to be fetched at once. The messages will still be processed one at a time.
+          prefetchCount: uint16
+          queueType: QueueType }
 
     and QueueType =
         | Quorum
         /// Deprecated. Use `Quorum` instead.
         | Classic
 
-    /// The number of unacked messages to pre-fetch.
-    /// This also defines the number of possible messages to be nacking concurrently.
-    [<Struct>]
-    type QueuePrefetchCount = TenMessages
 
-    type ReplyMessage = {
-        headers: List<string * string>
-        body: ReplyBody
-    }
+    type ReplyMessage =
+        { headers: List<string * string>
+          body: ReplyBody }
 
     and ReplyBody = Json of string
 
     let ackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
-        consumer.Channel
+        consumer
+            .Channel
             .BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false)
-            .AsTask ()
+            .AsTask()
         |> Async.AwaitTask
 
     let nackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
-        consumer.Channel
+        consumer
+            .Channel
             .BasicNackAsync(deliveryTag = event.DeliveryTag, multiple = false, requeue = true)
-            .AsTask ()
+            .AsTask()
         |> Async.AwaitTask
 
     /// The consumed message will be nacked after a specified delay. Will return after waiting for the delay.
     let private nackWithDelayBlockingAsync (delay: System.TimeSpan) : ReceivedMessage -> Async<unit> =
         fun message ->
             async {
-                do! Async.Sleep (int delay.TotalMilliseconds |> max 0 |> min System.Int32.MaxValue)
+                do!
+                    Async.Sleep(
+                        int delay.TotalMilliseconds
+                        |> max 0
+                        |> min System.Int32.MaxValue
+                    )
+
                 return! nackAsync message
             }
 
@@ -153,9 +156,14 @@ module Consumer =
             async {
                 // `StartChild` means we share the same `cancellation token`,
                 // so any exceptions should be propagated back to this call.
-                let! _ = nackWithDelayBlockingAsync delay message |> Async.StartChild
+                let! _ =
+                    nackWithDelayBlockingAsync delay message
+                    |> Async.StartChild
+
                 return ()
             }
+
+    let messageId (ReceivedMessage (event, _): ReceivedMessage) : string = event.BasicProperties.MessageId
 
     let messageBody (ReceivedMessage (event, _): ReceivedMessage) : string =
         System.Text.Encoding.UTF8.GetString event.Body.Span
@@ -173,7 +181,7 @@ module Consumer =
                 | _, null -> return Error "Missing message_id property."
 
                 | replyTo, correlationId ->
-                    let messageId = System.Guid.NewGuid().ToString ()
+                    let messageId = System.Guid.NewGuid().ToString()
 
                     let contentType, body =
                         match replyMessage.body with
@@ -186,14 +194,14 @@ module Consumer =
                         |> dict
 
                     do!
-                        consumer.Channel.BasicPublishAsync (
+                        consumer.Channel.BasicPublishAsync(
                             exchange = "",
                             routingKey = replyTo,
                             // mandatory should be false when publishing to a direct-reply-to queue (https://www.rabbitmq.com/direct-reply-to.html#limitations)
                             // which is a very common use case for replies.
                             mandatory = false,
                             basicProperties =
-                                BasicProperties (
+                                BasicProperties(
                                     ContentType = contentType,
                                     Persistent = true,
                                     MessageId = messageId,
@@ -203,66 +211,56 @@ module Consumer =
                             body = body
                         )
 
-                    return Ok ()
+                    return Ok()
 
-            with exn ->
-                return Error (string exn)
+            with
+            | exn -> return Error(string exn)
         }
         |> Async.AwaitTask
 
     /// <summary>Declares and optionally binds the specified queue, then starts consuming messages.</summary>
-    /// <param name="queuePrefetchCount">Maximum number of unacked messages to be fetched at once. The messages will still be processed one at a time.</param>
-    /// <param name="queueConfig">Queue configuration.</param>
-    let initAsync
-        (queuePrefetchCount: QueuePrefetchCount)
-        (queueConfig: QueueConfig)
-        (Connection connection: Connection)
-        : Async<Result<Model, string>> =
+    /// <param name="config">Queue configuration.</param>
+    let initAsync (config: QueueConfig) (Connection connection: Connection) : Async<Result<Model, string>> =
         task {
             try
-                let! channel = connection.CreateChannelAsync ()
+                let! channel = connection.CreateChannelAsync()
 
-                let prefetchCount =
-                    match queuePrefetchCount with
-                    | TenMessages -> 10us
-
-                do! channel.BasicQosAsync (uint32 0, prefetchCount, false)
+                do! channel.BasicQosAsync(uint32 0, config.prefetchCount, false)
 
                 channel.add_CallbackExceptionAsync (fun _ _ ->
                     task {
                         do!
-                            connection.AbortAsync (
+                            connection.AbortAsync(
                                 uint16 Constants.ChannelError,
                                 "RabbitMqClient.Consumer: Unhandled channel exception, closing connection",
                                 connectionCloseTimeout
                             )
-                    }
-                )
+                    })
 
                 let! _ =
-                    channel.QueueDeclareAsync (
-                        queue = queueConfig.queueName,
+                    channel.QueueDeclareAsync(
+                        queue = config.queueName,
                         durable = true,
                         exclusive = false,
                         autoDelete = false,
                         arguments =
                             dict (
                                 ("x-queue-type",
-                                 match queueConfig.queueType with
+                                 match config.queueType with
                                  | Quorum -> "quorum"
                                  | Classic -> "classic"
                                  :> obj)
-                                :: (queueConfig.messageTimeToLive
+                                :: (config.messageTimeToLive
                                     |> Option.map (fun ttl -> [ "x-message-ttl", ttl :> obj ])
                                     |> Option.defaultValue [])
                             )
                     )
 
-                if Option.isSome queueConfig.bindToExchange then
+                if Option.isSome config.bindToExchange then
                     do!
-                        channel.QueueBindAsync (
-                            queue = queueConfig.queueName,
-                            exchange = queueConfig.bindToExchange.Value,
+                        channel.QueueBindAsync(
+                            queue = config.queueName,
+                            exchange = config.bindToExchange.Value,
                             routingKey = "*",
                             arguments = null
                         )
@@ -270,52 +268,48 @@ module Consumer =
                 let consumer = AsyncEventingBasicConsumer channel
 
                 let consumerTag =
-                    $"%s{queueConfig.queueName}-consumer-%s{System.Guid.NewGuid().ToString ()}"
+                    $"%s{config.queueName}-consumer-%s{System.Guid.NewGuid().ToString()}"
 
                 consumer.add_ReceivedAsync (fun _ event ->
                     task {
                         if event.ConsumerTag = consumerTag then
-                            do! queueConfig.callbacks.onReceived (ReceivedMessage (event, consumer))
-                    }
-                )
+                            do! config.callbacks.onReceived (ReceivedMessage(event, consumer))
+                    })
 
                 consumer.add_RegisteredAsync (fun _ eventArgs ->
                     task {
-                        if eventArgs.ConsumerTags |> Array.contains consumerTag then
-                            queueConfig.callbacks.onRegistered queueConfig.queueName
-                    }
-                )
+                        if eventArgs.ConsumerTags
+                           |> Array.contains consumerTag then
+                            config.callbacks.onRegistered config.queueName
+                    })
 
                 consumer.add_UnregisteredAsync (fun _ eventArgs ->
                     task {
-                        if eventArgs.ConsumerTags |> Array.contains consumerTag then
+                        if eventArgs.ConsumerTags
+                           |> Array.contains consumerTag then
                             let replyCode, replyText =
                                 if consumer.ShutdownReason = null then
                                     0, "Missing ShutdownReason. Did the queue got deleted?"
                                 else
                                     int consumer.ShutdownReason.ReplyCode, consumer.ShutdownReason.ReplyText
 
-                            queueConfig.callbacks.onUnregistered {
-                                queueName = queueConfig.queueName
-                                replyCode = replyCode
-                                replyText = replyText
-                            }
-                    }
-                )
+                            config.callbacks.onUnregistered
+                                { queueName = config.queueName
+                                  replyCode = replyCode
+                                  replyText = replyText }
+                    })
 
                 consumer.add_ShutdownAsync (fun _ eventArgs ->
                     task {
-                        queueConfig.callbacks.onShutdown {
-                            queueName = queueConfig.queueName
-                            replyCode = int eventArgs.ReplyCode
-                            replyText = eventArgs.ReplyText
-                        }
-                    }
-                )
+                        config.callbacks.onShutdown
+                            { queueName = config.queueName
+                              replyCode = int eventArgs.ReplyCode
+                              replyText = eventArgs.ReplyText }
+                    })
 
                 let! _ =
-                    channel.BasicConsumeAsync (
-                        queue = queueConfig.queueName,
+                    channel.BasicConsumeAsync(
+                        queue = config.queueName,
                         autoAck = false,
                         consumerTag = consumerTag,
                         noLocal = false,
@@ -324,9 +318,10 @@ module Consumer =
                         consumer = consumer
                     )
 
-                return Ok (Consumer consumer)
+                return Ok(Consumer consumer)
 
-            with exn ->
+            with
+            | exn ->
                 // Abort connection gracefully on any unexpected error.
                 do! connection.AbortAsync connectionCloseTimeout
 
@@ -338,55 +333,52 @@ module Consumer =
     /// <param name="logger">Logger.</param>
     /// <param name="onReceivedAsync">Callback that's called when a new message is received.</param>
     /// <returns>Callbacks</returns>
-    let terminateOnUnexpectedEvents (logger: ILogger) (onReceivedAsync: ReceivedMessage -> Async<unit>) : Callbacks = {
-        onReceived =
+    let terminateOnUnexpectedEvents (logger: ILogger) (onReceivedAsync: ReceivedMessage -> Async<unit>) : Callbacks =
+        { onReceived =
             fun message ->
                 async {
                     try
                         do! onReceivedAsync message
-                    with exn ->
-                        logger.LogError (
-                            exn,
-                            "Got unexpected error during event `Received`. Will terminate the process"
-                        )
+                    with
+                    | exn ->
+                        logger.LogError(exn, "Got unexpected error during event `Received`. Will terminate the process")
 
                         exit 9
                 }
 
-        onRegistered = fun queueName -> logger.LogInformation ("Consumer registered on queue {queueName}", queueName)
+          onRegistered = fun queueName -> logger.LogInformation("Consumer registered on queue {queueName}", queueName)
 
-        onUnregistered =
-            fun event ->
-                // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
-                if event.replyCode <> Constants.ReplySuccess then
-                    logger.LogError (
-                        "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
-                        event.queueName,
-                        event.replyCode,
-                        event.replyText
-                    )
+          onUnregistered =
+              fun event ->
+                  // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                  if event.replyCode <> Constants.ReplySuccess then
+                      logger.LogError(
+                          "Got unexpected event `Unregistered` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                          event.queueName,
+                          event.replyCode,
+                          event.replyText
+                      )
 
-                    exit 11
+                      exit 11
 
-        onShutdown =
-            fun event ->
-                // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
-                if event.replyCode = Constants.ReplySuccess then
-                    logger.LogInformation (
-                        "Got expected event `Shutdown` for consumer on queue {queueName}",
-                        event.queueName
-                    )
+          onShutdown =
+              fun event ->
+                  // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
+                  if event.replyCode = Constants.ReplySuccess then
+                      logger.LogInformation(
+                          "Got expected event `Shutdown` for consumer on queue {queueName}",
+                          event.queueName
+                      )
 
-                else
-                    logger.LogError (
-                        "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
-                        event.queueName,
-                        event.replyCode,
-                        event.replyText
-                    )
+                  else
+                      logger.LogError(
+                          "Got unexpected event `Shutdown` for consumer on queue {queueName}. {replyCode} - {replyText}. Will terminate the process",
+                          event.queueName,
+                          event.replyCode,
+                          event.replyText
+                      )
 
-                    exit 13
-    }
+                      exit 13 }
 
 module RPC =
     open System.Threading
@@ -396,19 +388,17 @@ module RPC =
 
     and RequestAsync = RequestMessage -> Async<Result<ResponseMessage, string>>
 
-    and RequestMessage = {
-        queue: string
-        headers: List<string * string>
-        body: RequestBody
-        timeout: System.TimeSpan
-    }
+    and RequestMessage =
+        { queue: string
+          headers: List<string * string>
+          body: RequestBody
+          timeout: System.TimeSpan }
 
     and RequestBody = Json of string
 
-    and ResponseMessage = {
-        body: string
-        headers: System.Collections.Generic.IDictionary<string, obj>
-    }
+    and ResponseMessage =
+        { body: string
+          headers: System.Collections.Generic.IDictionary<string, obj> }
 
     type private CorrelationId = string
 
@@ -421,19 +411,19 @@ module RPC =
     let private requestAsync (pendingRequests: PendingRequests) (consumer: AsyncEventingBasicConsumer) : RequestAsync =
         fun message ->
             task {
-                let messageId = System.Guid.NewGuid().ToString ()
+                let messageId = System.Guid.NewGuid().ToString()
 
-                let completionSource = TaskCompletionSource<_> ()
+                let completionSource = TaskCompletionSource<_>()
 
-                use cancellationSource = new CancellationTokenSource (message.timeout)
+                use cancellationSource = new CancellationTokenSource(message.timeout)
 
                 let cancellationCallback () =
                     // Ensure the  pending request is removed to prevent memory leaks.
                     pendingRequests.TryRemove messageId |> ignore
 
                     // Try set error result.
-                    completionSource.TrySetResult (
-                        $"Request to queue '%s{message.queue}' timed out after %s{message.timeout.TotalSeconds.ToString ()}s"
+                    completionSource.TrySetResult(
+                        $"Request to queue '%s{message.queue}' timed out after %s{message.timeout.TotalSeconds.ToString()}s"
                         |> Error
                     )
                     |> ignore
@@ -441,27 +431,30 @@ module RPC =
                 // On received reply we will return from this function and `Dispose` will be called.
                 // `Dispose` will cancel the call to the callback.
                 use _cancellationRegistration =
-                    cancellationSource.Token.Register (
+                    cancellationSource.Token.Register(
                         callback = cancellationCallback,
                         useSynchronizationContext = false
                     )
 
                 try
-                    if pendingRequests.TryAdd (messageId, completionSource) then
+                    if pendingRequests.TryAdd(messageId, completionSource) then
                         let contentType, requestBody =
                             match message.body with
                             | Json json -> "application/json", System.Text.Encoding.UTF8.GetBytes json
 
-                        let requestHeaders = message.headers |> Seq.map (fun (k, v) -> k, v :> obj) |> dict
+                        let requestHeaders =
+                            message.headers
+                            |> Seq.map (fun (k, v) -> k, v :> obj)
+                            |> dict
 
                         do!
-                            consumer.Channel.BasicPublishAsync (
+                            consumer.Channel.BasicPublishAsync(
                                 exchange = "",
                                 routingKey = message.queue,
                                 // We don't care if the reply message got routed or not as we're using timeout.
                                 mandatory = false,
                                 basicProperties =
-                                    BasicProperties (
+                                    BasicProperties(
                                         ContentType = contentType,
                                         Persistent = false,
                                         MessageId = messageId,
@@ -476,8 +469,8 @@ module RPC =
                     else
                         return Error $"RabbitMqClient.RPC.request: Duplicate message id %s{messageId}"
 
-                with exn ->
-                    return Error (string exn)
+                with
+                | exn -> return Error(string exn)
             }
             |> Async.AwaitTask
 
@@ -488,26 +481,25 @@ module RPC =
         : Async<Result<Client, string>> =
         task {
             try
-                let pendingRequests: PendingRequests = ConcurrentDictionary ()
+                let pendingRequests: PendingRequests = ConcurrentDictionary()
 
                 let consumerTag =
                     queueDirectReplyTo
                     + "-"
                     + clientName
                     + "-consumer-"
-                    + System.Guid.NewGuid().ToString ()
+                    + System.Guid.NewGuid().ToString()
 
-                let! channel = connection.CreateChannelAsync ()
+                let! channel = connection.CreateChannelAsync()
 
                 channel.add_CallbackExceptionAsync (fun _ eventArgs ->
                     task {
                         let reason = $"%s{clientName}: Unhandled channel exception, closing connection"
 
-                        logger.LogError (eventArgs.Exception, reason)
+                        logger.LogError(eventArgs.Exception, reason)
 
-                        do! connection.AbortAsync (uint16 Constants.ChannelError, reason, connectionCloseTimeout)
-                    }
-                )
+                        do! connection.AbortAsync(uint16 Constants.ChannelError, reason, connectionCloseTimeout)
+                    })
 
                 let consumer = AsyncEventingBasicConsumer channel
 
@@ -517,36 +509,33 @@ module RPC =
 
                         match pendingRequests.TryRemove correlationId with
                         | true, tcs ->
-                            let responseMessage: ResponseMessage = {
-                                body = System.Text.Encoding.UTF8.GetString eventArgs.Body.Span
-                                headers = eventArgs.BasicProperties.Headers
-                            }
+                            let responseMessage: ResponseMessage =
+                                { body = System.Text.Encoding.UTF8.GetString eventArgs.Body.Span
+                                  headers = eventArgs.BasicProperties.Headers }
 
-                            if not (tcs.TrySetResult (Ok responseMessage)) then
-                                logger.LogWarning (
+                            if not (tcs.TrySetResult(Ok responseMessage)) then
+                                logger.LogWarning(
                                     "Consumer {clientName} received reply but unable to set task completion source with correlation id {correlationId}",
                                     clientName,
                                     correlationId
                                 )
 
                         | _ ->
-                            logger.LogWarning (
+                            logger.LogWarning(
                                 "Consumer {clientName} received reply without known correlation id: {correlationId}",
                                 clientName,
                                 correlationId
                             )
-                    }
-                )
+                    })
 
                 consumer.add_RegisteredAsync (fun _ eventArgs ->
                     task {
-                        logger.LogInformation (
+                        logger.LogInformation(
                             "Consumer {clientName} registered {consumerTags}",
                             clientName,
                             eventArgs.ConsumerTags
                         )
-                    }
-                )
+                    })
 
                 consumer.add_UnregisteredAsync (fun _ eventArgs ->
                     task {
@@ -558,31 +547,29 @@ module RPC =
 
                         // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
                         if replyCode <> Constants.ReplySuccess then
-                            logger.LogWarning (
+                            logger.LogWarning(
                                 "Consumer {clientName} unregistered {consumerTags}",
                                 clientName,
                                 eventArgs.ConsumerTags
                             )
-                    }
-                )
+                    })
 
                 consumer.add_ShutdownAsync (fun _ eventArgs ->
                     task {
                         if eventArgs.ReplyCode = uint16 Constants.ReplySuccess then
-                            logger.LogInformation ("Got expected event `Shutdown` for {clientName}", clientName)
+                            logger.LogInformation("Got expected event `Shutdown` for {clientName}", clientName)
 
                         else
-                            logger.LogWarning (
+                            logger.LogWarning(
                                 "Get unexpected event `Shutdown` for {clientName}. {replyCode} - {replyText}",
                                 clientName,
                                 eventArgs.ReplyCode,
                                 eventArgs.ReplyText
                             )
-                    }
-                )
+                    })
 
                 let! _ =
-                    channel.BasicConsumeAsync (
+                    channel.BasicConsumeAsync(
                         queue = queueDirectReplyTo,
                         autoAck = true, // Must be true for direct-reply-to.
                         consumerTag = consumerTag,
@@ -592,12 +579,9 @@ module RPC =
                         consumer = consumer
                     )
 
-                return
-                    Ok {
-                        requestAsync = requestAsync pendingRequests consumer
-                    }
+                return Ok { requestAsync = requestAsync pendingRequests consumer }
 
-            with exn ->
-                return Error (string exn)
+            with
+            | exn -> return Error(string exn)
         }
         |> Async.AwaitTask

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -129,7 +129,7 @@ module Consumer =
 
     and ReplyBody =
         | Json of string
-        | Binary of byte array
+        | Binary of byte[]
 
     let ackAsync (ReceivedMessage (event, consumer): ReceivedMessage) : Async<unit> =
         consumer.Channel.BasicAckAsync(deliveryTag = event.DeliveryTag, multiple = false).AsTask ()

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -385,11 +385,7 @@ module RPC =
     open System.Threading
     open System.Collections.Concurrent
 
-    type Client = { requestAsync: RequestAsync }
-
-    and RequestAsync = RequestMessage -> Async<Result<ResponseMessage, string>>
-
-    and RequestMessage = {
+    type RequestMessage = {
         queue: string
         headers: List<string * string>
         body: RequestBody
@@ -398,20 +394,40 @@ module RPC =
 
     and RequestBody = Json of string
 
-    and ResponseMessage = {
+    type ResponseHeaders = System.Collections.Generic.IDictionary<string, obj>
+
+    type RawResponseMessage = {
+        body: byte[]
+        headers: ResponseHeaders
+    }
+
+    type ResponseMessage = {
         body: string
-        headers: System.Collections.Generic.IDictionary<string, obj>
+        headers: ResponseHeaders
+    }
+
+    type RequestRawAsync = RequestMessage -> Async<Result<RawResponseMessage, string>>
+
+    type RequestAsync = RequestMessage -> Async<Result<ResponseMessage, string>>
+
+    type Client = {
+        requestRawAsync: RequestRawAsync
+        requestAsync: RequestAsync
     }
 
     type private CorrelationId = string
 
     type private PendingRequests =
-        ConcurrentDictionary<CorrelationId, TaskCompletionSource<Result<ResponseMessage, string>>>
+        ConcurrentDictionary<CorrelationId, TaskCompletionSource<Result<BasicDeliverEventArgs, string>>>
 
     [<Literal>]
     let private queueDirectReplyTo = "amq.rabbitmq.reply-to"
 
-    let private requestAsync (pendingRequests: PendingRequests) (consumer: AsyncEventingBasicConsumer) : RequestAsync =
+    let private requestRawAsync<'response>
+        (pendingRequests: PendingRequests)
+        (consumer: AsyncEventingBasicConsumer)
+        (mapResponse: ResponseHeaders -> System.ReadOnlyMemory<byte> -> 'response)
+        : RequestMessage -> Async<Result<'response, string>> =
         fun message ->
             task {
                 let messageId = System.Guid.NewGuid().ToString ()
@@ -464,7 +480,9 @@ module RPC =
                                 body = requestBody
                             )
 
-                        return! completionSource.Task
+                        match! completionSource.Task with
+                        | Error error -> return Error error
+                        | Ok response -> return Ok (mapResponse response.BasicProperties.Headers response.Body)
 
                     else
                         return Error $"RabbitMqClient.RPC.request: Duplicate message id %s{messageId}"
@@ -510,12 +528,7 @@ module RPC =
 
                         match pendingRequests.TryRemove correlationId with
                         | true, tcs ->
-                            let responseMessage: ResponseMessage = {
-                                body = System.Text.Encoding.UTF8.GetString eventArgs.Body.Span
-                                headers = eventArgs.BasicProperties.Headers
-                            }
-
-                            if not (tcs.TrySetResult (Ok responseMessage)) then
+                            if not (tcs.TrySetResult (Ok eventArgs)) then
                                 logger.LogWarning (
                                     "Consumer {clientName} received reply but unable to set task completion source with correlation id {correlationId}",
                                     clientName,
@@ -587,10 +600,39 @@ module RPC =
 
                 return
                     Ok {
-                        requestAsync = requestAsync pendingRequests consumer
+                        requestRawAsync =
+                            requestRawAsync
+                                pendingRequests
+                                consumer
+                                (fun headers body -> {
+                                    headers = headers
+                                    body = body.ToArray ()
+                                })
+
+                        requestAsync =
+                            requestRawAsync
+                                pendingRequests
+                                consumer
+                                (fun headers body -> {
+                                    headers = headers
+                                    body = System.Text.Encoding.UTF8.GetString body.Span
+                                })
                     }
 
             with exn ->
                 return Error (string exn)
         }
         |> Async.AwaitTask
+
+    module ResponseHeaders =
+        let inline has (key: string) (headers: ResponseHeaders) = headers.ContainsKey key
+
+        let string (key: string) (headers: ResponseHeaders) : Option<string> =
+            match headers.TryGetValue key with
+            | true, objectValue ->
+                match objectValue with
+                | :? System.ReadOnlyMemory<byte> as bytes -> Some (System.Text.Encoding.UTF8.GetString bytes.Span)
+
+                | _ -> None
+
+            | _ -> None

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -109,13 +109,15 @@ module Consumer =
 
     and QueueConfig = {
         queueName: string
-        bindToExchange: Option<string>
+        bindings: List<QueueBinding>
         callbacks: Callbacks
         messageTimeToLive: Option<int>
         /// Maximum number of unacked messages to be fetched at once. The messages will still be processed one at a time.
         prefetchCount: uint16
         queueType: QueueType
     }
+
+    and QueueBinding = { exchange: string; routingKey: string }
 
     and QueueType =
         | Quorum
@@ -253,12 +255,12 @@ module Consumer =
                             )
                     )
 
-                if Option.isSome config.bindToExchange then
+                for queueBinding in config.bindings do
                     do!
                         channel.QueueBindAsync (
                             queue = config.queueName,
-                            exchange = config.bindToExchange.Value,
-                            routingKey = "*", // TODO: Should be move this to config now, as this is really opinionated.
+                            exchange = queueBinding.exchange,
+                            routingKey = queueBinding.routingKey,
                             arguments = null
                         )
 
@@ -322,9 +324,6 @@ module Consumer =
                 return Ok (Consumer consumer)
 
             with exn ->
-                // Abort connection gracefully on any unexpected error. TODO: Remove this? Move to Program?
-                do! connection.AbortAsync connectionCloseTimeout
-
                 return Error $"RabbitMqClient.Consumer: %s{string exn}"
         }
         |> Async.AwaitTask

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -90,8 +90,6 @@ module Connection =
 
 module Consumer =
 
-    type Consumer = private Consumer of AsyncEventingBasicConsumer
-
     type ReceivedMessage = private ReceivedMessage of BasicDeliverEventArgs * AsyncEventingBasicConsumer
 
     type Callbacks = {
@@ -218,7 +216,7 @@ module Consumer =
 
     /// <summary>Declares and optionally binds the specified queue, then starts consuming messages.</summary>
     /// <param name="config">Queue configuration.</param>
-    let initAsync (config: QueueConfig) (Connection connection: Connection) : Async<Result<Consumer, string>> =
+    let initAsync (config: QueueConfig) (Connection connection: Connection) : Async<Result<unit, string>> =
         task {
             try
                 let! channel = connection.CreateChannelAsync ()
@@ -321,7 +319,7 @@ module Consumer =
                         consumer = consumer
                     )
 
-                return Ok (Consumer consumer)
+                return Ok ()
 
             with exn ->
                 return Error $"RabbitMqClient.Consumer: %s{string exn}"

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -629,18 +629,15 @@ module RPC =
         }
         |> Async.AwaitTask
 
-    module ResponseHeaders =
-        let inline has (key: string) (headers: ResponseHeaders) = headers.ContainsKey key
-
-        let string (key: string) (headers: ResponseHeaders) : Option<string> =
-            match headers.TryGetValue key with
-            | true, objectValue ->
-                match objectValue with
-                | :? System.ReadOnlyMemory<byte> as bytes -> Some (System.Text.Encoding.UTF8.GetString bytes.Span)
-
-                | _ -> None
+    let responseHeaderAsString (key: string) (headers: ResponseHeaders) : Option<string> =
+        match headers.TryGetValue key with
+        | true, objectValue ->
+            match objectValue with
+            | :? array<byte> as bytes -> Some (System.Text.Encoding.UTF8.GetString bytes)
 
             | _ -> None
+
+        | _ -> None
 
 module Publish =
 
@@ -651,7 +648,6 @@ module Publish =
         timeout: System.TimeSpan
     }
 
-    // TODO: Share with Consumer/RPC?
     and PublishMessageBody = Json of string
 
     type PublishAsync = PublishMessage -> Async<Result<unit, string>>


### PR DESCRIPTION
- Uses version  7.2.1 of `RabbitMQ.Client`
- Major overhaul of the API. In this version of the API it's encouraged to re-use a connection
