### PR TITLE
Log connected node endpoint

### DIFF
--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -15,7 +15,7 @@ module Connection =
 
     and OnConnectionShutdownEvent = {
         connectionName: string
-        connectionEndpoint: Endpoint
+        connectionEndpoint: string
         replyCode: int
         replyText: string
     }
@@ -28,11 +28,6 @@ module Connection =
         name: string
         vhost: string
         endpoints: List<System.Uri>
-    }
-
-    let private toEndpoint (endpoint: AmqpTcpEndpoint) : Endpoint = {
-        hostname = endpoint.HostName
-        port = endpoint.Port
     }
 
     let initAsync
@@ -56,15 +51,15 @@ module Connection =
                     )
 
                 logger.LogInformation (
-                    "Connected to RabbitMQ node endpoint {@nodeEndpoint}",
-                    toEndpoint connection.Endpoint
+                    "Connected to RabbitMQ node endpoint {connectionEndpoint}",
+                    string connection.Endpoint
                 )
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
                         onConnectionShutdown logger {
                             connectionName = config.name
-                            connectionEndpoint = toEndpoint connection.Endpoint
+                            connectionEndpoint = string connection.Endpoint
                             replyCode = int eventArgs.ReplyCode
                             replyText = eventArgs.ReplyText
                         }
@@ -92,7 +87,7 @@ module Connection =
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
                 logger.LogWarning (
-                    "Closing RabbitMQ connection {connectionName} on node endpoint {@connectionEndpoint}",
+                    "Closing RabbitMQ connection {connectionName} on node endpoint {connectionEndpoint}",
                     event.connectionName,
                     event.connectionEndpoint
                 )

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -15,9 +15,12 @@ module Connection =
 
     and OnConnectionShutdownEvent = {
         connectionName: string
+        connectionEndpoint: Endpoint
         replyCode: int
         replyText: string
     }
+
+    and Endpoint = { hostname: string; port: int }
 
     type CloseConnection = unit -> unit
 
@@ -25,6 +28,11 @@ module Connection =
         name: string
         vhost: string
         endpoints: List<System.Uri>
+    }
+
+    let endpoint (Connection connection) : Endpoint = {
+        hostname = connection.Endpoint.HostName
+        port = connection.Endpoint.Port
     }
 
     let initAsync
@@ -46,10 +54,13 @@ module Connection =
                         clientProvidedName = config.name
                     )
 
+                let exposedConnection = Connection connection
+
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
                         onConnectionShutdown {
                             connectionName = config.name
+                            connectionEndpoint = endpoint exposedConnection
                             replyCode = int eventArgs.ReplyCode
                             replyText = eventArgs.ReplyText
                         }
@@ -58,7 +69,7 @@ module Connection =
 
                 return
                     Ok (
-                        Connection connection,
+                        exposedConnection,
                         (fun () ->
                             connection.AbortAsync connectionCloseTimeout
                             |> Async.AwaitTask
@@ -76,7 +87,11 @@ module Connection =
         fun event ->
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
-                logger.LogWarning ("Closing RabbitMQ connection {connectionName}", event.connectionName)
+                logger.LogWarning (
+                    "Closing RabbitMQ connection {connectionName} on node endpoint {@connectionEndpoint}",
+                    event.connectionName,
+                    event.connectionEndpoint
+                )
 
             else if event.replyCode <> Constants.ReplySuccess then
                 logger.LogError (

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -56,7 +56,7 @@ module Connection =
                     )
 
                 logger.LogInformation (
-                    "Connected to RabbitMQ node endpoint {@rabbitMqNode}",
+                    "Connected to RabbitMQ node endpoint {@nodeEndpoint}",
                     toEndpoint connection.Endpoint
                 )
 

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -60,8 +60,6 @@ module Connection =
                     toEndpoint connection.Endpoint
                 )
 
-                let exposedConnection = Connection connection
-
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
                         onConnectionShutdown logger {
@@ -75,7 +73,7 @@ module Connection =
 
                 return
                     Ok (
-                        exposedConnection,
+                        Connection connection,
                         (fun () ->
                             connection.AbortAsync connectionCloseTimeout
                             |> Async.AwaitTask

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -11,7 +11,7 @@ let private connectionCloseTimeout = System.TimeSpan.FromSeconds 15.0
 
 module Connection =
 
-    type OnConnectionShutdown = OnConnectionShutdownEvent -> unit
+    type OnConnectionShutdown = ILogger -> OnConnectionShutdownEvent -> unit
 
     and OnConnectionShutdownEvent = {
         connectionName: string
@@ -30,12 +30,13 @@ module Connection =
         endpoints: List<System.Uri>
     }
 
-    let endpoint (Connection connection) : Endpoint = {
-        hostname = connection.Endpoint.HostName
-        port = connection.Endpoint.Port
+    let private toEndpoint (endpoint: AmqpTcpEndpoint) : Endpoint = {
+        hostname = endpoint.HostName
+        port = endpoint.Port
     }
 
     let initAsync
+        (logger: ILogger)
         (config: ConnectionConfig)
         (onConnectionShutdown: OnConnectionShutdown)
         : Async<Result<Connection * CloseConnection, string>> =
@@ -54,13 +55,18 @@ module Connection =
                         clientProvidedName = config.name
                     )
 
+                logger.LogInformation (
+                    "Connected to RabbitMQ node endpoint {@rabbitMqNode}",
+                    toEndpoint connection.Endpoint
+                )
+
                 let exposedConnection = Connection connection
 
                 connection.add_ConnectionShutdownAsync (fun _ eventArgs ->
                     task {
-                        onConnectionShutdown {
+                        onConnectionShutdown logger {
                             connectionName = config.name
-                            connectionEndpoint = endpoint exposedConnection
+                            connectionEndpoint = toEndpoint connection.Endpoint
                             replyCode = int eventArgs.ReplyCode
                             replyText = eventArgs.ReplyText
                         }
@@ -83,8 +89,8 @@ module Connection =
         |> Async.AwaitTask
 
     /// If the connection is unexpectedly closed the system will exit with error code 13.
-    let terminateOnUnexpectedShutdown (logger: ILogger) : OnConnectionShutdown =
-        fun event ->
+    let terminateOnUnexpectedShutdown: OnConnectionShutdown =
+        fun logger event ->
             // ReplySuccess (200) is passed when we close the connection from the client side, and thus is expected.
             if event.replyCode = Constants.ReplySuccess then
                 logger.LogWarning (

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -20,8 +20,6 @@ module Connection =
         replyText: string
     }
 
-    and Endpoint = { hostname: string; port: int }
-
     type CloseConnection = unit -> unit
 
     type ConnectionConfig = {


### PR DESCRIPTION
Logs the connected node on `initAsync`.

Breaking change to the public API.

Example log output:

```console
[09:18:39 INF RabbitMqClient.Connection] Connected to RabbitMQ node endpoint amqp://localhost:5672
...
[09:18:41 WRN RabbitMqClient.Connection] Closing RabbitMQ connection NAME on node endpoint amqp://localhost:5672
```

