### PR TITLE
Update connection config

### DIFF
--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -22,10 +22,14 @@ module Connection =
 
     type CloseConnection = unit -> unit
 
+    type Endpoint = { host: string; port: int }
+
     type ConnectionConfig = {
         name: string
+        username: string
+        password: string
         vhost: string
-        endpoints: List<System.Uri>
+        endpoints: List<Endpoint>
     }
 
     let initAsync
@@ -44,7 +48,12 @@ module Connection =
 
                 let! connection =
                     factory.CreateConnectionAsync (
-                        endpoints = List.map AmqpTcpEndpoint config.endpoints,
+                        endpoints =
+                            List.map
+                                (fun endpoint ->
+                                    AmqpTcpEndpoint (hostName = endpoint.host, portOrMinusOne = endpoint.port)
+                                )
+                                config.endpoints,
                         clientProvidedName = config.name
                     )
 

--- a/src/Insurello.RabbitMqClient/RabbitMqClient.fs
+++ b/src/Insurello.RabbitMqClient/RabbitMqClient.fs
@@ -43,7 +43,9 @@ module Connection =
                     ConnectionFactory (
                         AutomaticRecoveryEnabled = false,
                         RequestedHeartbeat = System.TimeSpan.FromSeconds 15.,
-                        VirtualHost = config.vhost
+                        VirtualHost = config.vhost,
+                        UserName = config.username,
+                        Password = config.password
                     )
 
                 let! connection =


### PR DESCRIPTION
### Problem
The username and password wasn't extracted from the endpoint uri:s.
### Solution
Configure the username and password in the `ConnectionConfig`.