### PR TITLE
Target net8.0 and net10.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     
         <PackageId>Insurello.RabbitMqClient</PackageId>
         <PackageDescription>A specialized F# wrapper around RabbitMq.Client</PackageDescription>


### PR DESCRIPTION
### Problem
Insurello.RabbitMqClient targets net8.0 only

### Solution
Upgrade the SDK to .NET 10 and multi-target `net8.0;net10.0` so the package works for both .NET 8 and .NET 10 consumers.