### PR TITLE
Set FSharp.Core to explicit minimum versions

### DIFF
--- a/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
+++ b/src/Insurello.RabbitMqClient/Insurello.RabbitMqClient.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     
         <PackageId>Insurello.RabbitMqClient</PackageId>
         <PackageDescription>A specialized F# wrapper around RabbitMq.Client</PackageDescription>
@@ -57,5 +57,13 @@
     <ItemGroup>
         <PackageReference Include="RabbitMq.Client" Version="7.2.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Update="FSharp.Core" Version="8.0.100" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Update="FSharp.Core" Version="10.0.100" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
When building the package on Github Actions the `FSharp.Core` version is set to the current version. Making the package to require that version or later.

### Solution
Set `FSharp.Core` to lowest version depending on target.